### PR TITLE
Makes the NATO rounds tooltip actually true, Fixes the bulletproof armor

### DIFF
--- a/code/_core/datum/damagetype/ranged/bullet/rifle_223.dm
+++ b/code/_core/datum/damagetype/ranged/bullet/rifle_223.dm
@@ -20,14 +20,12 @@
 
 	//The base attack damage of the weapon. It's a flat value, unaffected by any skills or attributes.
 	attack_damage_base = list(
-		BLUNT = 10,
 		PIERCE = 30
 	)
 
 	//How much armor to penetrate. It basically removes the percentage of the armor using these values.
 	attack_damage_penetration = list(
-		BLUNT = 50,
-		PIERCE = 65
+		PIERCE = 75
 	)
 
 	falloff = VIEW_RANGE + ZOOM_RANGE*0.5

--- a/code/_core/datum/damagetype/ranged/bullet/rifle_308.dm
+++ b/code/_core/datum/damagetype/ranged/bullet/rifle_308.dm
@@ -20,14 +20,12 @@
 
 	//The base attack damage of the weapon. It's a flat value, unaffected by any skills or attributes.
 	attack_damage_base = list(
-		BLUNT = 20,
-		PIERCE = 40
+		PIERCE = 50
 	)
 
 	//How much armor to penetrate. It basically removes the percentage of the armor using these values.
 	attack_damage_penetration = list(
-		BLUNT = 25,
-		PIERCE = 50
+		PIERCE = 60
 	)
 
 	falloff = VIEW_RANGE + ZOOM_RANGE

--- a/code/_core/obj/item/clothing/overwear/armor/bulletproof.dm
+++ b/code/_core/obj/item/clothing/overwear/armor/bulletproof.dm
@@ -10,8 +10,8 @@
 
 	defense_rating = list(
 		BLADE = 25,
-		BLUNT = 25,
-		PIERCE = 75,
+		BLUNT = 50,
+		PIERCE = 50,
 		LASER = -25,
 		MAGIC = -25
 	)


### PR DESCRIPTION
Change List:
1)The Bulletproof armor is only used by mannequins, and it having different values for Blunt and Pierce pen gives you a very poor idea of how strong a weapon actually is.
2)NATO rounds are now all Pierce damage, and weaker than Cartridge-designated rounds by 10 damage. This makes them worse against unarmored targets, but better against armored ones.
3)556 Retains better damage and DPS against Heavy armor (in the order of 75 pen), while 762 excels against unarmored or lightly armored targets.