### PR TITLE
gnarly zombie loadouts

### DIFF
--- a/code/_core/datum/gamemode/horde_types.dm
+++ b/code/_core/datum/gamemode/horde_types.dm
@@ -38,7 +38,13 @@
 		/mob/living/advanced/npc/zombie/chaplain = 5,
 		/mob/living/advanced/npc/zombie/security = 10,
 		/mob/living/advanced/npc/zombie/scientist = 5,
-		/mob/living/advanced/npc/zombie/librarian = 5
+		/mob/living/advanced/npc/zombie/librarian = 5,
+		/mob/living/advanced/npc/zombie/clown = 2,
+		/mob/living/advanced/npc/zombie/medical = 3,
+		/mob/living/advanced/npc/zombie/chemist = 2,
+		/mob/living/advanced/npc/zombie/bartender = 2,
+		/mob/living/advanced/npc/zombie/chef = 2
+
 	)
 	hidden = FALSE
 

--- a/code/_core/datum/loadout/zombie.dm
+++ b/code/_core/datum/loadout/zombie.dm
@@ -190,3 +190,127 @@
 	extra_weapon_chance = 0
 	extra_clothing_chance = 50
 
+
+/loadout/zombie/clown
+	spawning_items = list(
+		/obj/item/clothing/uniform/clown,
+		/obj/item/clothing/feet/shoes/clown,
+		/obj/item/clothing/feet/shoes/clown/left,
+		/obj/item/clothing/hands/gloves/colored,
+		/obj/item/clothing/hands/gloves/colored/left
+	)
+
+	possible_extra_clothing = list(
+		/obj/item/clothing/mask/gas/clown = 1
+	)
+
+	possible_extra_weapon = list(
+		/obj/item/fluff/bikehorn = 3,
+		/obj/item/container/pill/space_drugs = 1,
+		/obj/item/container/pill/space_dust = 1
+
+	)
+
+	extra_weapon_chance = 40
+	extra_clothing_chance = 85
+
+/loadout/zombie/medical
+	spawning_items = list(
+		/obj/item/clothing/overwear/coat/labcoat/medical,
+		/obj/item/clothing/underbottom/underwear/boxers/medical,
+		/obj/item/clothing/undertop/underwear/shirt,
+		/obj/item/clothing/shirt/normal/medical,
+		/obj/item/clothing/pants/normal/medical,
+		/obj/item/clothing/feet/shoes/colored,
+		/obj/item/clothing/feet/shoes/colored/left,
+		/obj/item/clothing/hands/gloves/colored,
+		/obj/item/clothing/hands/gloves/colored/left
+	)
+
+	possible_extra_clothing = list(
+		/obj/item/clothing/neck/tie/red = 1,
+		/obj/item/clothing/overwear/coat/labcoat/medical = 4,
+		/obj/item/clothing/glasses/prescription = 1,
+	)
+
+	possible_extra_weapon = list(
+		/obj/item/storage/kit/brute/filled = 1,
+		/obj/item/storage/kit/burn/filled = 1,
+		/obj/item/storage/kit/toxin/filled = 1,
+		/obj/item/storage/kit/brute/filled = 1
+	)
+
+	extra_weapon_chance = 30
+	extra_clothing_chance = 85
+
+/loadout/zombie/chemist
+	spawning_items = list(
+		/obj/item/clothing/underbottom/underwear/boxers,
+		/obj/item/clothing/uniform/chemist,
+		/obj/item/clothing/overwear/coat/labcoat/chemist,
+		/obj/item/clothing/feet/shoes/colored,
+		/obj/item/clothing/feet/shoes/colored/left,
+		/obj/item/clothing/hands/gloves/colored,
+		/obj/item/clothing/hands/gloves/colored/left,
+		/obj/item/clothing/neck/tie/red
+	)
+
+	possible_extra_clothing = list(
+		/obj/item/clothing/mask/gas = 3,
+		/obj/item/clothing/glasses/prescription = 1,
+	)
+
+	possible_extra_weapon = list(
+				/obj/item/container/syringe = 1,
+				/obj/item/container/beaker = 1,
+				/obj/item/storage/pillbottle/iron_small = 2,
+				/obj/item/storage/pillbottle/antihol_small = 1,
+	)
+
+	extra_weapon_chance = 40
+	extra_clothing_chance = 85
+
+/loadout/zombie/bartender
+	spawning_items = list(
+		/obj/item/clothing/feet/shoes/colored/black,
+		/obj/item/clothing/feet/shoes/colored/black/left,
+		/obj/item/clothing/neck/tie/red,
+		/obj/item/clothing/pants/normal/security,
+		/obj/item/clothing/shirt/normal
+	)
+
+	possible_extra_clothing = list(
+		/obj/item/clothing/glasses/sun = 1
+	)
+
+	possible_extra_weapon = list(
+		/obj/item/container/beaker/alcohol/whiskey = 3,
+		/obj/item/container/beaker/alcohol/beer = 4,
+		/obj/item/container/beaker/glass = 1,
+		/obj/item/container/beaker/shot = 1
+	)
+
+	extra_weapon_chance = 50
+	extra_clothing_chance = 85
+
+/loadout/zombie/chef
+	spawning_items = list(
+		/obj/item/clothing/feet/shoes/colored/black,
+		/obj/item/clothing/feet/shoes/colored/black/left,
+		/obj/item/clothing/pants/normal/security,
+		/obj/item/clothing/shirt/normal,
+		/obj/item/clothing/overwear/coat/apron/chef
+	)
+
+	possible_extra_clothing = list(
+		/obj/item/clothing/head/hat/chef = 1
+	)
+
+	possible_extra_weapon = list(
+		/obj/item/weapon/melee/sword/sabre = 5,
+		/obj/item/container/beaker/food/sugar = 1,
+		/obj/item/container/beaker/bottle/large/water = 1
+	)
+
+	extra_weapon_chance = 80
+	extra_clothing_chance = 75

--- a/code/_core/mob/living/advanced/human/npc/zombie.dm
+++ b/code/_core/mob/living/advanced/human/npc/zombie.dm
@@ -227,6 +227,27 @@
 	level_multiplier = 1
 	var/dropped_vial = FALSE
 
+/mob/living/advanced/npc/zombie/clown
+	loadout_to_use = /loadout/zombie/clown
+	level_multiplier = 8
+
+/mob/living/advanced/npc/zombie/medical
+	loadout_to_use = /loadout/zombie/medical
+	level_multiplier = 4
+
+/mob/living/advanced/npc/zombie/chemist
+	loadout_to_use = /loadout/zombie/chemist
+	level_multiplier = 4
+
+/mob/living/advanced/npc/zombie/bartender
+	loadout_to_use = /loadout/zombie/bartender
+	level_multiplier = 3
+
+/mob/living/advanced/npc/zombie/chef
+	loadout_to_use = /loadout/zombie/chef
+	level_multiplier = 3
+
+
 /mob/living/advanced/npc/zombie/scientist/post_death()
 
 	if(!dropped_vial)


### PR DESCRIPTION
-adds clown, bartender, chef, medical and chemist loadouts for zombies (with some rare goodies too)
-adds em in the horde groups as fairly uncommon
![unknown](https://user-images.githubusercontent.com/9487319/94273257-742a2700-ff44-11ea-9d54-274aba1d8944.png)
-nice