### PR TITLE
Adds examine text to a bunch of shit

### DIFF
--- a/code/_core/obj/item/cell_charger.dm
+++ b/code/_core/obj/item/cell_charger.dm
@@ -132,3 +132,12 @@
 		return FALSE
 
 	return .
+	
+/obj/item/cell_charger/get_examine_list(var/mob/caller)
+	
+	. = ..()
+	
+	if(battery)
+		. += div("notice","Charge Remaining: [battery.charge_current]")
+		
+	return .

--- a/code/_core/obj/item/hand_tele.dm
+++ b/code/_core/obj/item/hand_tele.dm
@@ -128,3 +128,6 @@
 	update_sprite()
 
 	return TRUE
+	
+/obj/item/hand_teleporter/get_examine_list(var/mob/caller)
+	return ..() + div("notice","Teleports Remaining: [FLOOR(battery.charge_current/30000,1)]")

--- a/code/_core/obj/item/powercell/_powercell.dm
+++ b/code/_core/obj/item/powercell/_powercell.dm
@@ -134,3 +134,5 @@
 /obj/item/powercell/recharging/think()
 	charge_current = min(charge_current + charge_max*0.001,charge_max)
 	return ..()
+	
+Zembaflemba/Persistent-Bay

--- a/code/_core/obj/item/powercell/_powercell.dm
+++ b/code/_core/obj/item/powercell/_powercell.dm
@@ -135,4 +135,5 @@
 	charge_current = min(charge_current + charge_max*0.001,charge_max)
 	return ..()
 	
-Zembaflemba/Persistent-Bay
+/obj/item/powercell/get_examine_list(var/mob/caller)
+	return ..() + div("notice","It has [charge_current] out of [charge_max] charge remaining.")

--- a/code/_core/obj/item/weapon/ranged/bullet/magazine/_magazine.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/magazine/_magazine.dm
@@ -154,3 +154,12 @@
 			play('sound/effects/gun_empty_sound.ogg',caller, pitch = 1 + sound_strength*0.5, volume = 100 * sound_strength)
 
 	return .
+	
+/obj/item/weapon/ranged/bullet/magazine/get_examine_list(var/mob/caller)
+
+	. = ..()
+
+	if(stored_magazine)
+		. += div("notice","[length(stored_magazine.stored_bullets)] bullet\s remaining in the magazine.")
+
+	return .

--- a/code/_core/obj/item/weapon/ranged/bullet/pump/_pump.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/pump/_pump.dm
@@ -42,3 +42,6 @@
 
 /obj/item/weapon/ranged/bullet/pump/can_load_chamber(var/mob/caller,var/obj/item/bullet_cartridge/B)
 	return FALSE
+	
+/obj/item/weapon/ranged/bullet/pump/get_examine_list(var/mob/caller)
+	return ..() + div("notice","[get_ammo_count()] shell\s remaining in the tube.")

--- a/code/_core/obj/item/weapon/ranged/laser/_laser.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/_laser.dm
@@ -123,3 +123,6 @@
 		return FALSE
 
 	return TRUE
+	
+/obj/item/weapon/ranged/energy/get_examine_list(var/mob/caller)
+	return ..() + div("notice","[get_ammo_count()] shot\s remaining at the current charge level.")


### PR DESCRIPTION
Power Cells now display their level of charge on examine.
Hand Teleporters display how many teleports you have left.
Device Chargers now display how much charge the cell inside of it has.
Ranged weapons aside from revolvers now display how many bullets are left in the magazine/internal magazine.
Laser weapons now now display how many shots you have left according to current level of charge.

Yell at me if I typed something wrong or whatever, or if you know how to code the above for revolvers, because I have no idea how.

(Pay no attention to the first commit that was just a copy-paste error.)