### PR TITLE
Add Battery to Restocker

### DIFF
--- a/code/_core/obj/structure/interactive/restocker.dm
+++ b/code/_core/obj/structure/interactive/restocker.dm
@@ -34,6 +34,21 @@
 
 /obj/structure/interactive/restocker/ammo/clicked_on_by_object(var/mob/caller,var/atom/object,location,control,params)
 
+
+	if(istype(object,/obj/item/powercell/))
+		INTERACT_CHECK
+		INTERACT_CHECK_OBJECT
+		INTERACT_DELAY(5)
+		var/obj/item/powercell/C = object
+		if(C.charge_current >= C.charge_max)
+			caller.to_chat(span("warning","You can't cram any more power into the [C.name]!"))
+			return TRUE
+		if(C.charge_current <= C.charge_max)
+			C.charge_current = C.charge_max
+			caller.to_chat(span("notice","You swap the [C.name] for a fully charged one."))
+			C.update_sprite()
+			return TRUE
+
 	if(istype(object,/obj/item/magazine/))
 		INTERACT_CHECK
 		INTERACT_CHECK_OBJECT


### PR DESCRIPTION
Adds code necessary to allow batteries to be "restocked" by an ammo restocker.

# What this PR does
Allows players to click a portable ammo restocker with a battery to "recharge" the battery.

# Why it should be added to the game
We have infinite bullets, but not infinite batteries? Maybe having to buy new mags every single time they run out is the reason no one uses energy guns.