### PR TITLE
12.7 auto nerf

### DIFF
--- a/code/_core/obj/item/weapon/ranged/bullet/magazine/pistol/overseer.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/magazine/pistol/overseer.dm
@@ -6,7 +6,7 @@
 	icon_state = "inventory"
 	value = 350
 
-	shoot_delay = 2
+	shoot_delay = 3
 
 	automatic = FALSE
 


### PR DESCRIPTION
Firerate from 2>3
Requested change in trello

# What this PR does
Changes the 12.7 Auto "Overseer" pistols fire delay from 2>3

# Why it should be added to the game
Hell if I know, but a nerf was requested on trello.