### PR TITLE
Fixes Wielded weapon spreads

### DIFF
--- a/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/pdw.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/pdw.dm
@@ -70,8 +70,8 @@
 
 
 /obj/item/weapon/ranged/bullet/magazine/rifle/pdw/get_static_spread()
-	if(wielded) return 0.01
-	return 0.005
+	if(wielded) return 0.005
+	return 0.01
 
 /obj/item/weapon/ranged/bullet/magazine/rifle/pdw/get_skill_spread(var/mob/living/L)
 	if(!heat_current) return 0

--- a/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/pulse.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/pulse.dm
@@ -71,6 +71,10 @@
 
 	firing_pin = /obj/item/firing_pin/electronic/iff/deathsquad
 
+/obj/item/weapon/ranged/bullet/magazine/rifle/pulse/get_static_spread()
+	if(wielded) return 0
+	return 0.15
+
 /obj/item/weapon/ranged/bullet/magazine/rifle/pulse/update_icon()
 
 	if(stored_magazine)

--- a/code/_core/obj/item/weapon/ranged/laser/iongun.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/iongun.dm
@@ -36,6 +36,7 @@
 	can_wield = TRUE
 
 /obj/item/weapon/ranged/energy/iongun/get_static_spread()
+	if(wielded) return 0
 	return 0.001
 
 /obj/item/weapon/ranged/energy/iongun/get_skill_spread(var/mob/living/L)

--- a/code/_core/obj/item/weapon/ranged/laser/laser_rifle.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/laser_rifle.dm
@@ -69,6 +69,7 @@
 	attachment_undermount_offset_y = 12 - 16
 
 /obj/item/weapon/ranged/energy/rifle/get_static_spread()
+	if(wielded) return 0
 	return 0.0005
 
 /obj/item/weapon/ranged/energy/rifle/get_skill_spread(var/mob/living/L)


### PR DESCRIPTION

# What this PR does
Makes PDW now more accurate when wielded (Fixes a bug)
Adds spread values to pulse rifle
Makes Ion Gun more accurate when Wielded
Makes Laser Rifle more accurate when Wielded


# Why it should be added to the game
It fixes a bug and adds an accuracy bonus for weapons that were previously wieldable, but provided no bonus for doing so.