### PR TITLE
fishing fixes part 841147328942

### DIFF
--- a/code/_core/obj/item/fishing/bait.dm
+++ b/code/_core/obj/item/fishing/bait.dm
@@ -34,6 +34,8 @@
 	desc_extended = "Bait for sea fishing. Will get you some salty fish, and will never be consumed on successful catches."
 	value = 700
 	nice_bait = TRUE
+	item_count_current = 1
+	item_count_max = 1
 
 
 //River
@@ -54,6 +56,8 @@
 	desc_extended = "Bait for river fishing. Will get you fresh fish, and will never be consumed on successful catches."
 	value = 700
 	nice_bait = TRUE
+	item_count_current = 1
+	item_count_max = 1
 
 //Lava
 /obj/item/fishing/bait/lava

--- a/code/_core/obj/item/fishing/lure.dm
+++ b/code/_core/obj/item/fishing/lure.dm
@@ -34,7 +34,7 @@
 
 	chance_bonus = -2
 	time_bonus = 10
-	rarity_bonus = -CHANCE_GOOD
+	rarity_bonus = -10
 
 	value = 250
 

--- a/code/_core/obj/item/fishing/rod.dm
+++ b/code/_core/obj/item/fishing/rod.dm
@@ -140,6 +140,7 @@
 					QDEL_NULL(bait)
 					QDEL_NULL(lure)
 					QDEL_NULL(fishing_bob)
+					update_sprite()
 					fishing_turf = null
 					return FALSE
 

--- a/code/_core/turf/simulated/hazard/_hazard.dm
+++ b/code/_core/turf/simulated/hazard/_hazard.dm
@@ -1,7 +1,7 @@
 /turf/simulated/hazard/
 	density = TRUE
 
-	var/loot/fishing_rewards = /loot/fishing/sea //Default
+	var/loot/fishing_rewards
 
 /turf/simulated/hazard/is_safe_teleport()
 	return FALSE

--- a/code/_core/turf/simulated/hazard/lava.dm
+++ b/code/_core/turf/simulated/hazard/lava.dm
@@ -5,6 +5,7 @@
 	icon_state = "lava"
 
 	footstep = /footstep/lava
+	fishing_rewards = /loot/fishing/lava
 
 	plane = PLANE_FLOOR
 

--- a/code/_core/turf/simulated/hazard/water.dm
+++ b/code/_core/turf/simulated/hazard/water.dm
@@ -7,6 +7,7 @@
 	collision_bullet_flags = FLAG_COLLISION_BULLET_NONE
 
 	footstep = /footstep/water
+	fishing_rewards = /loot/fishing/river
 
 	density_north = TRUE
 	density_east = TRUE
@@ -25,3 +26,4 @@
 
 /turf/simulated/hazard/water/sea
 	name = "saltwater"
+	fishing_rewards = /loot/fishing/sea


### PR DESCRIPTION
# What this PR does
-ahoy me matey we be patchin arghhhhh
-possibly fixes endless bait dupe (and makes it not stackable)
-bandaids the easy bobber as it was disgustingly bad previously
-adds a spam check to the fishing rod and a short moment before fish can start biting (its a singular second dw)
-fixes the fishing rod sprite not updating when simply removing or losing the line
-gives fishable tiles their actual reward pools as they would all default to sea previously
# Why it should be added to the game
https://user-images.githubusercontent.com/9487319/107103107-c5182900-681c-11eb-8a18-106e1ee46569.mp4
