### PR TITLE
rcd bandaid

### DIFF
--- a/code/_core/obj/item/disk/_disk.dm
+++ b/code/_core/obj/item/disk/_disk.dm
@@ -16,7 +16,7 @@
 	drop_sound = 'sound/items/drop/card.ogg'
 
 	weight = 0.5
-
+/*
 /obj/item/disk/save_item_data(var/save_inventory = TRUE)
 	. = ..()
 	SAVEVAR("data")
@@ -26,7 +26,7 @@
 	. = ..()
 	LOADVAR("data")
 	return .
-
+*/
 /obj/item/disk/New(var/desired_loc)
 	. = ..()
 	update_sprite()

--- a/code/_core/obj/item/weapon/melee/tool/rcd.dm
+++ b/code/_core/obj/item/weapon/melee/tool/rcd.dm
@@ -16,11 +16,14 @@
 /obj/item/rcd/save_item_data(var/save_inventory = TRUE)
 	. = ..()
 	SAVEATOM("rcd_disk")
+	SAVEVAR("matter_current")
 	return .
 
 /obj/item/rcd/load_item_data_pre(var/mob/living/advanced/player/P,var/list/object_data)
 	. = ..()
 	LOADATOM("rcd_disk")
+	LOADVAR("matter_current")
+	update_sprite()
 	return .
 
 /obj/item/rcd/Generate()


### PR DESCRIPTION
# What this PR does
-RCDs now save how much matters they got in them!!!!!!!! wowie zowie
-fixed RCD disks becoming borked after a save'n'load by disabling disks saving data as none of the disks used rn require to since they dont change at any point
# Why it should be added to the game
becoase i said so
🥇 <-- for me becos im am cool