### PR TITLE
Antag no drag non-antag body, no dead body in crate

### DIFF
--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -200,3 +200,17 @@ mob/living/advanced/player/on_life_client()
 
 
 	return .
+
+/mob/living/advanced/player/can_be_grabbed(var/atom/grabber,var/messages=TRUE)
+	// only prevent dead bodies from being grabbed if person grabbing is antag
+	// unfortunately due to code in datum/damagetype/unarmed/fists.dm, a GRAB! message will be displayed anyway
+	if(dead && istype(grabber, /mob/living/advanced/player/antagonist/))
+		if(istype(src, /mob/living/advanced/player/antagonist/))
+			return ..() // person being grabbed is also antag, allows revs and syndies to grab each other (maybe check IFF?)
+		
+		if(messages)
+			var/mob/living/grabberMob = grabber
+			grabberMob.to_chat(span("warning", "Ew! Why would I touch a disgusting [name]!"))
+		
+		return FALSE
+	return ..()

--- a/code/_core/obj/structure/interactive/crate/_crate.dm
+++ b/code/_core/obj/structure/interactive/crate/_crate.dm
@@ -118,6 +118,11 @@
 /obj/structure/interactive/crate/proc/can_store(var/atom/movable/M)
 	if(M.anchored)
 		return FALSE
+	if(istype(M, /mob/living/advanced/player/))
+		var/mob/living/advanced/player/playerCorpse = M
+		if(playerCorpse.dead)
+			visible_message(span("warning", "\The [playerCorpse.name] hilariously looses balance and falls out of the crate!"))
+			return FALSE
 	return TRUE
 
 /obj/structure/interactive/crate/proc/can_prevent_close(var/atom/movable/M)


### PR DESCRIPTION
# What this PR does
Antags can no longer drag non-antag corpses, but antag corpses can be dragged by non-antags (should this be changed?).
Player corpses can no longer be put into crates.

# Why it should be added to the game
Borgar idea