### PR TITLE
TURBO NERFS the runeblade

### DIFF
--- a/code/_core/obj/item/weapon/ranged/magic/spellblade.dm
+++ b/code/_core/obj/item/weapon/ranged/magic/spellblade.dm
@@ -71,13 +71,21 @@
 
 /obj/item/weapon/ranged/magic/spellblade/runesword
 	name = "rune sword"
+	desc = "This sword was made for those who are too lazy to walk up to people to stab them."
+	desc_extended = "A force-blade that was forged by Dwarven runesmiths, in a time long forgotten. It is capable of firing a potent long-range beam."
 	icon = 'icons/obj/item/weapons/ranged/magic/runesword.dmi'
 	icon_state = "inventory"
+
+	value = 1500
+	rarity = RARITY_RARE
 
 	projectile = /obj/projectile/magic/blade
 	damage_type = /damagetype/melee/sword/claymore
 	damage_type_on = /damagetype/melee/sword/spellblade
 	ranged_damage_type = /damagetype/ranged/magic/spellblade
+
+	size = SIZE_4
+	weight = 20
 
 	shoot_delay = SECONDS_TO_DECISECONDS(1)
 


### PR DESCRIPTION
# What this PR does
Gives the rune blade proper value, weight, size, rarity, and adds descriptions
I kinda just eyeballed the plightbringer and gave it weight and value based on that, rather than my personal feelings on how heavy it should be or how much it should be valued.
# Why it should be added to the game
Reduces the amount of rune blades you can fit into a single pocket slot from 30 to 0