### PR TITLE
Big pouch better now

### DIFF
--- a/code/_core/obj/item/storage/pouch.dm
+++ b/code/_core/obj/item/storage/pouch.dm
@@ -40,7 +40,7 @@
 	desc_extended = "Storage pouches attachable to the groin or chest. This one can carry one Size 4 item, such as bulky guns."
 	icon_state = "single"
 
-	container_max_size = SIZE_3
+	container_max_size = SIZE_4
 	dynamic_inventory_count = 1
 
 	size = SIZE_4


### PR DESCRIPTION
# What this PR does

Changes the container_max_size of the single large pouch from SIZE_3 to SIZE_4
# Why it should be added to the game

Description says max size 4, but actual max size 3, why game lie to me?