### PR TITLE
Player Rev Earpiece

### DIFF
--- a/code/_core/datum/loadout/rev_new.dm
+++ b/code/_core/datum/loadout/rev_new.dm
@@ -152,6 +152,7 @@
 
 /loadout/rev/player_antagonist
 	spawning_items = list(
+		/obj/item/clothing/ears/headset,
 		/obj/item/clothing/pants/gorka,
 		/obj/item/clothing/shirt/gorka,
 		/obj/item/clothing/overwear/armor/seva/mono,


### PR DESCRIPTION
# What this PR does
Gives player revs an earpiece.

# Why it should be added to the game
They cant currently talk over comms.