### PR TITLE
epic temper menu

### DIFF
--- a/code/_core/obj/item/tempering/_tempering.dm
+++ b/code/_core/obj/item/tempering/_tempering.dm
@@ -20,12 +20,13 @@
 		if(can_temper(caller,object))
 			INTERACT_CHECK
 			INTERACT_CHECK_OBJECT
-			INTERACT_DELAY(5)
 			if(caller.attack_flags & CONTROL_MOD_ALT)
 				on_temper(caller,object)
 				return TRUE
 			else
 				var/choice = input("Do you want to temper \the [object.name]?","Alt+Click to skip this next time") as null|anything in list("Yes","No")
+				INTERACT_CHECK
+				INTERACT_CHECK_OBJECT
 				if(choice == "Yes")
 					on_temper(caller,object)
 					return TRUE

--- a/code/_core/obj/item/tempering/_tempering.dm
+++ b/code/_core/obj/item/tempering/_tempering.dm
@@ -20,10 +20,15 @@
 		if(can_temper(caller,object))
 			INTERACT_CHECK
 			INTERACT_CHECK_OBJECT
-			INTERACT_DELAY(10)
-			on_temper(caller,object)
-			return TRUE
-
+			INTERACT_DELAY(5)
+			if(caller.attack_flags & CONTROL_MOD_ALT)
+				on_temper(caller,object)
+				return TRUE
+			else
+				var/choice = input("Do you want to temper \the [object.name]?","Alt+Click to skip this next time") as null|anything in list("Yes","No")
+				if(choice == "Yes")
+					on_temper(caller,object)
+					return TRUE
 	return ..()
 
 /obj/item/tempering/proc/can_temper(var/mob/caller,var/obj/item/I)


### PR DESCRIPTION
# What this PR does
-adds a yes/no prompt when clicking stuff using a tempering item (can be skipped by holding alt)
-no more "FUCK I UPGRADED MY SATCHEL"s
sidenote i removed the interact delay as it would be finicky with the menu plus this doesnt spam much besides the client? hopefully its fine
# Why it should be added to the game
![epik](https://user-images.githubusercontent.com/9487319/108004634-aa9d3700-6ff6-11eb-94fc-42422e95e7e7.JPG)
cool beans