### PR TITLE
Freezegun buff and AER tweek

### DIFF
--- a/code/_core/datum/damagetype/ranged/laser/freezegun.dm
+++ b/code/_core/datum/damagetype/ranged/laser/freezegun.dm
@@ -4,11 +4,11 @@
 	//The base attack damage of the weapon. It's a flat value, unaffected by any skills or attributes.
 	attack_damage_base = list(
 		LASER = DAMAGE_AXE*0.25,
-		COLD = DAMAGE_AXE*0.75,
+		COLD = DAMAGE_CLUB*1,
 	)
 
 	//How much armor to penetrate. It basically removes the percentage of the armor using these values.
 	attack_damage_penetration = list(
-		COLD = AP_AXE*0.5,
+		COLD = AP_CLUB*0.5,
 		LASER = AP_AXE*0.5
 	)

--- a/code/_core/obj/item/weapon/ranged/laser/freezegun.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/freezegun.dm
@@ -8,13 +8,14 @@
 	ranged_damage_type = /damagetype/ranged/laser/freezegun
 
 	projectile_speed = TILE_SIZE - 1
-	shoot_delay = 3
+	shoot_delay = 4
 
-	automatic = FALSE
+	automatic = TRUE
 
 	bullet_color = "#00FFFF"
 
 	charge_cost = CELL_SIZE_BASIC / 30
+
 
 	view_punch = 8
 
@@ -29,6 +30,39 @@
 	weight = 15
 
 	value = 1500
+
+
+	attachment_whitelist = list(
+		/obj/item/attachment/barrel/charger = FALSE,
+		/obj/item/attachment/barrel/compensator = FALSE,
+		/obj/item/attachment/barrel/extended = FALSE,
+		/obj/item/attachment/barrel/gyro = FALSE,
+		/obj/item/attachment/barrel/laser_charger = TRUE, /obj/item/attachment/barrel/laser_charger/advanced = TRUE,
+		/obj/item/attachment/barrel/suppressor = FALSE,
+
+		/obj/item/attachment/sight/laser_sight = TRUE,
+		/obj/item/attachment/sight/quickfire_adapter = TRUE,
+		/obj/item/attachment/sight/red_dot = TRUE,
+		/obj/item/attachment/sight/scope = FALSE,
+		/obj/item/attachment/sight/scope/large = FALSE,
+		/obj/item/attachment/sight/targeting_computer = TRUE,
+
+		/obj/item/attachment/stock/c20r = FALSE,
+
+		/obj/item/attachment/undermount/angled_grip = TRUE,
+		/obj/item/attachment/undermount/bipod = TRUE,
+		/obj/item/attachment/undermount/burst_adapter = FALSE,
+		/obj/item/attachment/undermount/vertical_grip = TRUE
+	)
+
+	attachment_barrel_offset_x = 31 - 16
+	attachment_barrel_offset_y = 15 - 16
+
+	attachment_sight_offset_x = 17 - 16
+	attachment_sight_offset_y = 22 - 16
+
+	attachment_undermount_offset_x = 27 - 16
+	attachment_undermount_offset_y = 12 - 14
 
 /obj/item/weapon/ranged/energy/freezegun/get_static_spread()
 	return 0.001

--- a/code/_core/obj/item/weapon/ranged/laser/freezegun.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/freezegun.dm
@@ -37,8 +37,7 @@
 		/obj/item/attachment/barrel/compensator = FALSE,
 		/obj/item/attachment/barrel/extended = FALSE,
 		/obj/item/attachment/barrel/gyro = FALSE,
-		/obj/item/attachment/barrel/laser_charger = TRUE, 
-		/obj/item/attachment/barrel/laser_charger/advanced = TRUE,
+		/obj/item/attachment/barrel/laser_charger = TRUE, /obj/item/attachment/barrel/laser_charger/advanced = TRUE,
 		/obj/item/attachment/barrel/suppressor = FALSE,
 
 		/obj/item/attachment/sight/laser_sight = TRUE,

--- a/code/_core/obj/item/weapon/ranged/laser/freezegun.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/freezegun.dm
@@ -37,7 +37,8 @@
 		/obj/item/attachment/barrel/compensator = FALSE,
 		/obj/item/attachment/barrel/extended = FALSE,
 		/obj/item/attachment/barrel/gyro = FALSE,
-		/obj/item/attachment/barrel/laser_charger = TRUE, /obj/item/attachment/barrel/laser_charger/advanced = TRUE,
+		/obj/item/attachment/barrel/laser_charger = TRUE, 
+		/obj/item/attachment/barrel/laser_charger/advanced = TRUE,
 		/obj/item/attachment/barrel/suppressor = FALSE,
 
 		/obj/item/attachment/sight/laser_sight = TRUE,

--- a/code/_core/obj/item/weapon/ranged/laser/laser_rifle.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/laser_rifle.dm
@@ -41,7 +41,7 @@
 		/obj/item/attachment/barrel/compensator = FALSE,
 		/obj/item/attachment/barrel/extended = FALSE,
 		/obj/item/attachment/barrel/gyro = FALSE,
-		/obj/item/attachment/barrel/laser_charger = TRUE,
+		/obj/item/attachment/barrel/laser_charger = TRUE, /obj/item/attachment/barrel/laser_charger/advanced = TRUE,
 		/obj/item/attachment/barrel/suppressor = FALSE,
 
 		/obj/item/attachment/sight/laser_sight = TRUE,

--- a/code/_core/obj/item/weapon/ranged/laser/laser_rifle.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/laser_rifle.dm
@@ -47,8 +47,8 @@
 		/obj/item/attachment/sight/laser_sight = TRUE,
 		/obj/item/attachment/sight/quickfire_adapter = TRUE,
 		/obj/item/attachment/sight/red_dot = TRUE,
-		/obj/item/attachment/sight/scope = TRUE,
-		/obj/item/attachment/sight/scope/large = TRUE,
+		/obj/item/attachment/sight/scope = FALSE,
+		/obj/item/attachment/sight/scope/large = FALSE,
 		/obj/item/attachment/sight/targeting_computer = TRUE,
 
 		/obj/item/attachment/stock/c20r = FALSE,


### PR DESCRIPTION
# What this PR does
Gives the freezegun a much needed damage boost and allows it to mount the same attachments as the AER. Also removes the ability to put a scope on your AER

# Why it should be added to the game

The freezegun is pathetic in comparison to the other laser weapons available to the crew. I buffed the cold damage it does as well as gave the cold damage some better penetration and allowed the gun to take attachments. This should put the gun on an even playing field with the other laser weapons.

The AER lost the ability to mount a scope because it is useless on that gun without the ability to wield the weapon with both hands.