### PR TITLE
mmm yes more greentide

### DIFF
--- a/code/_core/datum/gamemode/horde_types.dm
+++ b/code/_core/datum/gamemode/horde_types.dm
@@ -122,6 +122,9 @@
 	)
 	hidden = FALSE
 
+	enemies_to_spawn_base = 10
+	enemies_to_spawn_per_player = 1.5
+
 /gamemode/horde/boss_rush
 	name = "Horde Mode (Boss Rush)"
 	desc = "Oh god oh fuck."

--- a/code/_core/datum/loot/goblin.dm
+++ b/code/_core/datum/loot/goblin.dm
@@ -11,5 +11,5 @@
 		/obj/item/material/ingot/gold = 100,
 		/obj/item/clothing/overwear/coat/drip = 1
 	)
-	chance_none = 90
+	chance_none = 80
 	loot_count = 3

--- a/code/_core/mob/living/simple/goblin.dm
+++ b/code/_core/mob/living/simple/goblin.dm
@@ -25,7 +25,7 @@
 	blood_type = /reagent/blood/goblin
 	blood_volume = 300
 
-	move_delay = AI_TICK
+	move_delay = AI_TICK*2
 
 	stun_angle = 90
 


### PR DESCRIPTION
# What this PR does
Increases goblin spawn to 10, and +1.5 for each player.
Increases loot drop chance to 20% on death, previously 10%.
Doubles the speed of the current unarmed goblins.

# Why it should be added to the game
Goblins dropped relatively bad loot on a 10% drop in groups that could contain 4-8 goblins, and not all of them could even be stunted goblins. This should make at least half a token drop per wave, and make the more advanced loot feel less painful to farm since its less finding the goblins, and more grinding goblins into patties. 

Goblin's speed was increased so the horde is more of a threat instead of a crawling loot farm. As much of a threat as unarmored goblins can be, at least.