### PR TITLE
Rev Update (kang doesn't fuck up as hard edition)

### DIFF
--- a/code/_core/datum/loadout/rev_new.dm
+++ b/code/_core/datum/loadout/rev_new.dm
@@ -159,6 +159,8 @@
 		/obj/item/clothing/head/hat/skimask/black,
 		/obj/item/clothing/hands/gloves/colored/padded/black,
 		/obj/item/clothing/hands/gloves/colored/padded/black/left,
+		/obj/item/clothing/feet/socks/knee,
+		/obj/item/clothing/feet/socks/knee,
 		/obj/item/clothing/feet/shoes/black_boots,
 		/obj/item/clothing/feet/shoes/black_boots/left,
 		/obj/item/clothing/belt/storage/colored/black,


### PR DESCRIPTION
# What this PR does
Gives rev antags socks

# Why it should be added to the game
Revs don't have socks for some reason. This fixes that to give them a minor speed boost.