### PR TITLE
BoH & SoH buff

### DIFF
--- a/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
+++ b/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
@@ -7,7 +7,7 @@
 
 
 	dynamic_inventory_count = MAX_INVENTORY_X*4
-	container_max_size = SIZE_5
+	container_max_size = SIZE_15
 
 	size = MAX_INVENTORY_X*4*SIZE_5
 
@@ -27,7 +27,7 @@
 	icon = 'icons/obj/item/clothing/back/satchel/bluespace.dmi'
 
 	dynamic_inventory_count = MAX_INVENTORY_X*4
-	container_max_size = SIZE_4
+	container_max_size = SIZE_10
 
 	size = MAX_INVENTORY_X*4*SIZE_4
 


### PR DESCRIPTION
# What this PR does
BoH new max item size is 15, so you can store heavier items like armor. Much-needed to make it more viable then the Syndie duffelbag. 
SoH new max item size is 10, you can store heavier items, but not the heaviest.

# Why it should be added to the game
People usually use the Syndie bag over the BoH because that extra line of inventory space isn't too useful compared to the zero-slowdown of the Syndie bag. Plus, a way to store things like powerarmor for selling/storage is nice.
