### PR TITLE
BoH and SoH buffs

### DIFF
--- a/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
+++ b/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
@@ -7,7 +7,7 @@
 
 
 	dynamic_inventory_count = MAX_INVENTORY_X*4
-	container_max_size = SIZE_5
+	container_max_size = SIZE_5*3
 
 	size = MAX_INVENTORY_X*4*SIZE_5
 
@@ -27,7 +27,7 @@
 	icon = 'icons/obj/item/clothing/back/satchel/bluespace.dmi'
 
 	dynamic_inventory_count = MAX_INVENTORY_X*4
-	container_max_size = SIZE_4
+	container_max_size = SIZE_4*3
 
 	size = MAX_INVENTORY_X*4*SIZE_4
 


### PR DESCRIPTION
# What this PR does
BoH can now hold size 15 items. This makes it so you can store heavier armors.
SoH can now hold size 12 items. Not as heavy as the BoH but still, you can store some heavy stuff.

# Why it should be added to the game
BoH and SoH aren't really used, because people prefer the zero-slowdown of the Syndie bags. This PR makes them viable for use in trading/hauling/storage and more shit.