### PR TITLE
Untangles the Rune Sword a little bit.

### DIFF
--- a/code/_core/obj/item/weapon/ranged/magic/spellblade.dm
+++ b/code/_core/obj/item/weapon/ranged/magic/spellblade.dm
@@ -81,7 +81,7 @@
 	projectile_speed = TILE_SIZE*0.25 - 1
 
 	projectile = /obj/projectile/magic/blade
-	damage_type = /damagetype/melee/sword/claymore
+	damage_type = /damagetype/melee/sword/spellblade
 	damage_type_on = /damagetype/melee/sword/spellblade
 	ranged_damage_type = /damagetype/ranged/magic/spellblade
 


### PR DESCRIPTION
# What this PR does
Instead of having different damage and attack speed whether in the different modes, this just makes it so the only thing toggling the sword does is allow you to shoot the ranged bit. 

# Why it should be added to the game
This'll solve problems like trying to melee stuff and firing the projectile and not being able to attack with that hand for a few seconds.