### PR TITLE
Change back SpaceLube water recipe!

### DIFF
--- a/code/_core/datum/reagent_recipe/misc.dm
+++ b/code/_core/datum/reagent_recipe/misc.dm
@@ -110,7 +110,7 @@
 	name = "Space Lube"
 
 	required_reagents = list(
-		/reagent/oxygen = 1,
+		/reagent/nutrition/water = 1,
 		/reagent/silicon = 1,
 		/reagent/potassium = 1,
 	)


### PR DESCRIPTION
The trick is to Add silicon first. THEN Add water and potassium at 10u each NOT 60u!

# Why it should be added to the game

Why the difficulty? so it's not as easily accessible to grefing greytides. Just don't be an idiot.