### PR TITLE
le canman buff

### DIFF
--- a/code/_core/datum/ai/boss/can_man.dm
+++ b/code/_core/datum/ai/boss/can_man.dm
@@ -9,7 +9,7 @@
 	var/projectile_delay = 10
 
 	var/strafe_count = 10
-	var/strafe_delay = 60
+	var/strafe_delay = 30
 
 /ai/boss/can_man/New(var/desired_loc,var/mob/living/desired_owner)
 	owner_as_can_man = desired_owner
@@ -80,7 +80,7 @@
 
 	if(projectile_count > 0)
 		play_sound('sound/weapons/canman_shot.ogg',get_turf(owner))
-		owner.shoot_projectile(owner,objective_attack,null,null,/obj/projectile/bullet/firearm/pistol,/damagetype/ranged/bullet/pistol_8mm,16,16,0,TILE_SIZE*0.5,1,"#FF4A00",0,0,1,owner.iff_tag,owner.loyalty_tag)
+		owner.shoot_projectile(owner,objective_attack,null,null,/obj/projectile/bullet/firearm/pistol,/damagetype/ranged/bullet/pistol_45,16,16,0,TILE_SIZE*0.5,1,"#FF4A00",0,0,1,owner.iff_tag,owner.loyalty_tag)
 		owner.set_dir(get_dir(owner,objective_attack))
 		projectile_count--
 	else


### PR DESCRIPTION
# What this PR does
Halves canman's strafe delay
changes his bullets from 8mm to 45mm

# Why it should be added to the game
Canman drops really good loot for mid-endgame stuff, but fights like he's supposed to be the same as slime king or king crab. Gigabuffing his dps in the hopes that he finally stands a chance against a swarm of players with good armor. No, you cant afk tank the minigun anymore but should anyone really be standing still in front of the bullet stream in the first place?