### PR TITLE
Eggs, cheese, and cheese crafting areas

### DIFF
--- a/code/_core/area/hellscape/exterior.dm
+++ b/code/_core/area/hellscape/exterior.dm
@@ -35,6 +35,7 @@
 /area/hellscape/exterior/death_plains
 	name = "Death Plains"
 	icon_state = "meat"
+	cheese_type = /reagent/nutrition/cheese/blackash
 
 /area/hellscape/interior/caves
 	name = "Caves"
@@ -42,11 +43,27 @@
 
 	sound_environment = ENVIRONMENT_QUARRY
 
+	cheese_type = /reagent/nutrition/cheese/gruyere
+
+/area/hellscape/interior/caves/cave_river
+	name = "Cave River"
+	icon_state = "cyan"
+
+	cheese_type = /reagent/nutrition/cheese/oasis
+
+
 /area/hellscape/interior/caves/watersource
 	name = "Watersource Caves"
 	icon_state = "pink"
+	cheese_type = /reagent/nutrition/cheese/gruyere
 
 	sound_environment = ENVIRONMENT_CAVE
+
+/area/hellscape/interior/caves/puddle
+	name = "Puddle"
+	icon_state = "cyan"
+
+	cheese_type = /reagent/nutrition/cheese/oasis
 
 /area/hellscape/interior/caves/hive
 	name = "\improper Hive"
@@ -54,11 +71,15 @@
 
 	sound_environment = ENVIRONMENT_CAVE
 
+	cheese_type = /reagent/nutrition/cheese/brabander
+
 /area/hellscape/interior/caves/ancient
 	name = "Caves of the Ancient"
 	icon_state = "disposals"
 
 	sound_environment = ENVIRONMENT_CAVE
+
+	cheese_type = /reagent/nutrition/cheese/guava
 
 /area/hellscape/interior/caves/crash
 	name = "Crashed Ship"
@@ -66,14 +87,19 @@
 
 	sound_environment = ENVIRONMENT_CAVE
 
+	cheese_type = /reagent/nutrition/cheese/brabander
+
 /area/hellscape/interior/caves/hellchamber
 	name = "Lava Caves Hellchamber"
 	icon_state = "volcanic"
 
+	cheese_type = /reagent/nutrition/cheese/guava
 
 /area/hellscape/interior/caves/lava_lake
 	name = "Eastern Lava Lake"
 	icon_state = "yellow"
+
+	cheese_type = /reagent/nutrition/cheese/guava
 
 	sound_environment = ENVIRONMENT_CAVE
 
@@ -83,27 +109,39 @@
 
 	sound_environment = ENVIRONMENT_CAVE
 
+	cheese_type = /reagent/nutrition/cheese/oasis
+
 /area/hellscape/interior/caves/broodmother
 	name = "Broodmother's Nest"
 	icon_state = "green"
 
 	sound_environment = ENVIRONMENT_CAVE
 
+	cheese_type = /reagent/nutrition/cheese/gruyere
+
 /area/hellscape/interior/caves/ashwalker_village
 	name = "Ashwalker's Village"
 	icon_state = "village"
+
+	cheese_type = /reagent/nutrition/cheese/blackash
 
 /area/hellscape/interior/caves/rev
 	name = "Revolutionary Base Outskirts"
 	icon_state = "blue"
 
+	cheese_type = /reagent/nutrition/cheese/brabander
+
 /area/hellscape/interior/caves/crab
 	name = "Crab Cave"
 	icon_state = "orange"
 
+	cheese_type = /reagent/nutrition/cheese/kadchgall
+
 /area/hellscape/interior/caves/syndicate
 	name = "Syndicate Base Outskirts"
 	icon_state = "blue"
+
+	cheese_type = /reagent/nutrition/cheese/brabander
 
 /area/hellscape/interior/pirate_landing
 	name = "Pirate's Landing"
@@ -111,11 +149,15 @@
 
 	sound_environment = ENVIRONMENT_CONCERT_HALL
 
+	cheese_type = /reagent/nutrition/cheese/oasis
+
 /area/hellscape/interior/rev
 	name = "Revolutionary Base"
 	icon_state = "library"
 
 	sound_environment = ENVIRONMENT_STONEROOM
+
+	cheese_type = /reagent/nutrition/cheese/brabander
 
 /area/hellscape/interior/supermatter
 	name = "Supermatter Substation"
@@ -123,16 +165,24 @@
 
 	sound_environment = ENVIRONMENT_STONEROOM
 
+	cheese_type = /reagent/nutrition/cheese/cheddar
+
 /area/hellscape/interior/syndicate
 	name = "Syndicate Base"
 	icon_state = "syndicate"
 
 	sound_environment = ENVIRONMENT_STONEROOM
 
+	cheese_type = /reagent/nutrition/cheese/cheddar
+
 /area/hellscape/interior/syndicate/aux
 	name = "Syndicate Aux Base"
 	icon_state = "syndicate"
 
+	cheese_type = /reagent/nutrition/cheese/cheddar
+
 /area/hellscape/interior/syndicate/canman
 	name = "Syndicate Testing Chambers"
 	icon_state = "syndicate"
+
+	cheese_type = /reagent/nutrition/cheese/cheddar

--- a/code/_core/datum/reagent/reagent_nutrition_milk.dm
+++ b/code/_core/datum/reagent/reagent_nutrition_milk.dm
@@ -37,7 +37,7 @@
 	color = "#FFC237"
 
 	nutrition_amount = 20
-	nutrition_quality_amount = -6
+	nutrition_quality_amount = -9
 
 	flavor = "processed cheese"
 
@@ -52,8 +52,9 @@
 	desc = "Nutrition and flavor from Kadchgall cheese."
 	color = "#FFE8AA"
 
-	nutrition_amount = 30
-	nutrition_quality_amount = -3
+	nutrition_amount = 40
+	nutrition_quality_amount = 6
+	hydration_amount = -15
 
 	flavor = "processed cheese"
 
@@ -66,8 +67,8 @@
 	desc = "Nutrition and flavor from cheddar cheese."
 	color = "#FF9F00"
 
-	nutrition_amount = 30
-	nutrition_quality_amount = -6
+	nutrition_amount = 35
+	nutrition_quality_amount = -9
 
 	flavor = "sharp cheddar cheese"
 
@@ -81,8 +82,9 @@
 	desc = "Nutrition and flavor from Old Brabander Jungle cheese."
 	color = "#FFFCE8"
 
-	nutrition_amount = 30
-	nutrition_quality_amount = -3
+	nutrition_amount = 20
+	nutrition_quality_amount = 9
+
 
 	flavor = "sweet and creamy caramel cheese"
 
@@ -97,8 +99,10 @@
 	desc = "Nutrition and flavor from Raclette Alpine cheese."
 	color = "#FFF09F"
 
-	nutrition_amount = 30
-	nutrition_quality_amount = -3
+	nutrition_amount = 15 //less nutrition is stronger in this case, preventing the gaining of weight that would further hinder stamina
+	nutrition_quality_amount = -6
+	heal_factor = 9 //supposed to be healing at the cost of nutrition, probably not going to be balanced properly without extensive testing post-merge
+
 
 	flavor = "sweet nutty cheese"
 
@@ -112,8 +116,8 @@
 	desc = "Nutrition and flavor from Gruyère cave cheese."
 	color = "#E4A300"
 
-	nutrition_amount = 30
-	nutrition_quality_amount = -3
+	nutrition_amount = 25
+	nutrition_quality_amount = 6
 
 	flavor = "sweet and salty nutty cream cheese"
 
@@ -127,8 +131,8 @@
 	desc = "Nutrition and flavor from Smoked Guava cheese."
 	color = "#704226"
 
-	nutrition_amount = 30
-	nutrition_quality_amount = -3
+	nutrition_amount = 20
+	nutrition_quality_amount = 9
 
 	flavor = "sweet fudge cheese"
 
@@ -142,10 +146,41 @@
 	desc = "Nutrition and flavor from bluespace cheese."
 	color = "#78A093"
 
-	nutrition_amount = 30
+	nutrition_amount = 20
 	nutrition_quality_amount = 0
 
 	flavor = "bluespace cheese"
+
+	liquid = 0.2
+
+	flags_flavor = FLAG_FLAVOR_DAIRY | FLAG_FLAVOR_LOVE | FLAG_FLAVOR_FAT
+
+
+/reagent/nutrition/cheese/oasis
+	name = "Glardin Oasis cheese"
+	desc = "Nutrition and flavor from Glardin Oasis cheese."
+	color = "#3D62C3"
+
+	nutrition_amount = 10
+	nutrition_quality_amount = 3
+	hydration_amount = 20
+
+	flavor = "salty waterlogged cheese"
+
+	liquid = 0.2
+
+	flags_flavor = FLAG_FLAVOR_DAIRY | FLAG_FLAVOR_LOVE | FLAG_FLAVOR_FAT
+
+/reagent/nutrition/cheese/blackash
+	name = "Black Ash cheese"
+	desc = "Nutrition and flavor from Black Ash cheese."
+	color = "#3f3f3f"
+
+	nutrition_amount = -30
+	nutrition_quality_amount = 0
+	hydration_amount = -20
+
+	flavor = "scorched rocks and smokey ash cheese"
 
 	liquid = 0.2
 
@@ -165,4 +200,3 @@
 	value = 2
 
 	flags_flavor = FLAG_FLAVOR_LOVE | FLAG_FLAVOR_FAT
-

--- a/code/_core/obj/item/container/food/egg.dm
+++ b/code/_core/obj/item/container/food/egg.dm
@@ -10,5 +10,5 @@
 
 /obj/item/container/food/egg/chicken/Generate()
 	reagents.add_reagent(/reagent/nutrition/egg_white,3)
-	reagents.add_reagent(/reagent/nutrition/egg_yellow,2)
+	reagents.add_reagent(/reagent/nutrition/egg_yellow,3)
 	return ..()


### PR DESCRIPTION
# What this PR does
Changes eggs from 3/2 white/yolk to 3/3 for baking

Adds Black Ash cheese and Glardin Oasis cheese

Rebalances ALL cheese so that default is okay, but all the others have unique uses and applications, all of which outperform processed cheese in a unique way.

# Why it should be added to the game
Cheese needs a reason to go out and get anything other than bluespace.