### PR TITLE
Hellscape QOL Changes

### DIFF
--- a/maps/horde/hellscape.dmm
+++ b/maps/horde/hellscape.dmm
@@ -4417,29 +4417,48 @@
 /obj/structure/interactive/crate/chest/filled,
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/hellchamber)
-"ws" = (
-/obj/marker/map_node,
-/turf/simulated/floor/plating,
-/area/hellscape/interior/caves/watersource)
-"xm" = (
+"vu" = (
 /obj/structure/interactive/lighting/fixture/floor/strong,
 /turf/simulated/floor/plating,
 /area/hellscape/interior/caves/watersource)
-"yx" = (
-/obj/structure/scenery/rocks,
+"wj" = (
 /turf/simulated/floor/plating,
 /area/hellscape/interior/caves/watersource)
-"yP" = (
+"wr" = (
+/obj/structure/smooth/table/dark,
+/obj/item/weapon/melee/tool/wirecutters,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"xU" = (
+/obj/structure/smooth/table/dark,
+/obj/item/weapon/melee/toolbox/blue,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"zH" = (
+/obj/structure/smooth/table/dark,
+/obj/structure/interactive/computer/console/laptop,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"Fj" = (
+/obj/marker/spawning/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"JA" = (
+/obj/marker/map_node,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/caves/watersource)
+"Qg" = (
 /obj/structure/interactive/lighting/fixture/tube/station{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hellscape/interior/supermatter)
-"Ck" = (
-/obj/marker/spawning/window/reinforced,
+"Qo" = (
+/obj/structure/smooth/table/dark,
+/obj/item/weapon/melee/toolbox/red,
 /turf/simulated/floor/plating,
 /area/hellscape/interior/supermatter)
-"CI" = (
+"RM" = (
 /obj/structure/interactive/lighting/fixture/tube/station{
 	dir = 4
 	},
@@ -4448,43 +4467,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/hellscape/interior/supermatter)
-"Ek" = (
-/obj/structure/smooth/table/dark,
-/obj/item/weapon/melee/toolbox/blue,
-/turf/simulated/floor/plating,
-/area/hellscape/interior/supermatter)
-"FG" = (
+"RZ" = (
 /obj/structure/interactive/emitter{
 	dir = 8;
 	icon_state = "emitter"
 	},
 /turf/simulated/floor/plating,
 /area/hellscape/interior/supermatter)
-"NR" = (
-/turf/simulated/floor/plating,
-/area/hellscape/interior/caves/watersource)
-"Ss" = (
+"Vp" = (
 /obj/structure/interactive/emitter{
 	dir = 1;
 	icon_state = "emitter"
 	},
 /turf/simulated/floor/tile/dark,
 /area/hellscape/interior/supermatter)
-"Wi" = (
-/obj/structure/smooth/table/dark,
-/obj/item/weapon/melee/toolbox/red,
+"WJ" = (
+/obj/structure/scenery/rocks,
 /turf/simulated/floor/plating,
-/area/hellscape/interior/supermatter)
-"Xw" = (
-/obj/structure/smooth/table/dark,
-/obj/item/weapon/melee/tool/wirecutters,
-/turf/simulated/floor/plating,
-/area/hellscape/interior/supermatter)
-"Zd" = (
-/obj/structure/smooth/table/dark,
-/obj/structure/interactive/computer/console/laptop,
-/turf/simulated/floor/plating,
-/area/hellscape/interior/supermatter)
+/area/hellscape/interior/caves/watersource)
 
 (1,1,1) = {"
 ja
@@ -36050,7 +36050,7 @@ eU
 eU
 eU
 eU
-eU
+fv
 cj
 ar
 cd
@@ -36306,7 +36306,7 @@ eU
 ar
 eU
 hq
-fv
+eU
 eU
 ar
 eU
@@ -36556,8 +36556,8 @@ cd
 eU
 eU
 hq
-eU
 fv
+eU
 eU
 eU
 eU
@@ -37073,11 +37073,11 @@ ar
 eU
 rb
 rb
-Zd
-Ek
-CI
-Xw
-Wi
+zH
+xU
+RM
+wr
+Qo
 rb
 rb
 eU
@@ -37580,11 +37580,11 @@ aq
 aq
 aq
 eU
-xm
-NR
-NR
-NR
-ws
+vu
+wj
+wj
+wj
+JA
 rb
 rm
 rm
@@ -37594,11 +37594,11 @@ rm
 rm
 rm
 rb
-ws
-NR
-NR
-NR
-xm
+JA
+wj
+wj
+wj
+vu
 eU
 eU
 aq
@@ -37837,7 +37837,7 @@ aq
 aq
 aq
 eU
-NR
+wj
 rb
 rb
 rb
@@ -37845,9 +37845,9 @@ rh
 rb
 rk
 rb
-Ck
-Ck
-Ck
+Fj
+Fj
+Fj
 rb
 rk
 rb
@@ -37855,7 +37855,7 @@ ro
 rd
 rd
 rd
-NR
+wj
 eU
 aq
 aq
@@ -38094,7 +38094,7 @@ aq
 aq
 aq
 aq
-NR
+wj
 rb
 re
 re
@@ -38112,7 +38112,7 @@ rg
 re
 re
 rb
-yx
+WJ
 aq
 aq
 aq
@@ -39910,7 +39910,7 @@ re
 re
 rg
 re
-Ss
+Vp
 rb
 aq
 aq
@@ -41443,9 +41443,9 @@ rh
 rb
 rk
 rb
-Ck
-Ck
-Ck
+Fj
+Fj
+Fj
 rb
 rk
 rb
@@ -41958,7 +41958,7 @@ rb
 rm
 rm
 rm
-FG
+RZ
 rm
 rm
 rm
@@ -42215,7 +42215,7 @@ rb
 rb
 rm
 rm
-yP
+Qg
 rm
 rm
 rb

--- a/maps/horde/hellscape.dmm
+++ b/maps/horde/hellscape.dmm
@@ -130,22 +130,22 @@
 /area/hellscape/interior/syndicate/canman)
 "aJ" = (
 /obj/structure/shuttle_engine/burst/right{
-	icon_state = "burst_r";
-	dir = 1
+	dir = 1;
+	icon_state = "burst_r"
 	},
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/watersource)
 "aK" = (
 /obj/structure/shuttle_engine/propulsion{
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion"
 	},
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/watersource)
 "aL" = (
 /obj/structure/shuttle_engine/burst/left{
-	icon_state = "burst_l";
-	dir = 1
+	dir = 1;
+	icon_state = "burst_l"
 	},
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/watersource)
@@ -251,11 +251,11 @@
 /turf/simulated/floor/colored/sand/underwater,
 /area/hellscape/interior/caves/watersource)
 "bl" = (
+/obj/structure/smooth/table/rack/grey,
+/obj/item/clothing/head/helmet/hardsuit/exosuit,
 /obj/structure/interactive/lighting/fixture/tube/station/strong{
 	dir = 8
 	},
-/obj/structure/smooth/table/rack/grey,
-/obj/item/clothing/head/helmet/hardsuit/exosuit,
 /turf/simulated/floor/tile/dark,
 /area/hellscape/interior/rev)
 "bm" = (
@@ -466,8 +466,8 @@
 /area/hellscape/interior/caves/ashwalker_village)
 "cm" = (
 /mob/living/advanced/npc/ashwalker/warrior{
-	icon_state = "directional";
-	dir = 4
+	dir = 4;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/ashwalker_village)
@@ -553,8 +553,8 @@
 /area/hellscape/exterior/jungle/north)
 "cG" = (
 /mob/living/advanced/npc/deathsquad/heavy{
-	icon_state = "directional";
-	dir = 4
+	dir = 4;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/plating/shuttle,
 /area/hellscape/interior/caves/watersource)
@@ -870,8 +870,8 @@
 /area/hellscape/exterior/jungle/north)
 "dU" = (
 /mob/living/advanced/npc/deathsquad/medium{
-	icon_state = "directional";
-	dir = 4
+	dir = 4;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/watersource)
@@ -1138,8 +1138,8 @@
 /area/hellscape/interior/syndicate/aux)
 "fd" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 8
+	dir = 8;
+	icon_state = ""
 	},
 /turf/simulated/wall/dark,
 /area/hellscape/interior/syndicate/aux)
@@ -1230,12 +1230,16 @@
 /turf/simulated/floor/grass/jungle,
 /area/hellscape/exterior/jungle/north)
 "fy" = (
-/turf/simulated/floor/colored/dirt,
-/area/hellscape/interior/caves/broodmother)
+/obj/structure/interactive/lighting/fixture/tube/station/strong{
+	dir = 8
+	},
+/obj/item/storage/heavy/trash_pile,
+/turf/simulated/floor/tile/dark,
+/area/hellscape/interior/rev)
 "fz" = (
 /mob/living/advanced/npc/ashwalker/assassin{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/colored/ash/necro,
 /area/hellscape/interior/caves/ashwalker_village)
@@ -1371,15 +1375,15 @@
 /area/hellscape/interior/caves/ashwalker_village)
 "gc" = (
 /mob/living/advanced/npc/ashwalker/assassin{
-	icon_state = "directional";
-	dir = 1
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/ashwalker_village)
 "gd" = (
 /mob/living/advanced/npc/ashwalker/assassin{
-	icon_state = "directional";
-	dir = 4
+	dir = 4;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/colored/ash/necro,
 /area/hellscape/interior/caves/ashwalker_village)
@@ -1508,8 +1512,8 @@
 /area/hellscape/interior/syndicate/aux)
 "gI" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 8
+	dir = 8;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal/reinforced/syndicate,
 /area/hellscape/interior/syndicate/aux)
@@ -1659,8 +1663,8 @@
 /area/hellscape/interior/caves/watersource)
 "hr" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 1
+	dir = 1;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal/reinforced/syndicate,
 /area/hellscape/interior/syndicate/aux)
@@ -1693,9 +1697,17 @@
 /turf/simulated/floor/cave_dirt,
 /area/hellscape/interior/caves/watersource)
 "hy" = (
-/obj/marker/map_node,
-/turf/simulated/floor/basalt,
-/area/hellscape/interior/caves/broodmother)
+/obj/structure/interactive/crate/medical,
+/obj/item/defib,
+/obj/item/container/spray/silver_sulfadiazine,
+/obj/item/container/spray/styptic_powder,
+/obj/item/container/medicine/trauma_kit/advanced,
+/obj/item/container/medicine/burn_kit/advanced,
+/obj/item/storage/kit/syndicate/filled,
+/obj/item/container/medicine/burn_kit/advanced,
+/obj/item/container/medicine/trauma_kit/advanced,
+/turf/simulated/floor/tile/dark,
+/area/hellscape/interior/rev)
 "hz" = (
 /obj/marker/syndicate,
 /turf/simulated/floor/colored/ash/dark,
@@ -1741,12 +1753,19 @@
 /turf/simulated/floor/grass/jungle,
 /area/hellscape/exterior/jungle/north)
 "hI" = (
-/turf/simulated/floor/colored/dirt/soil,
-/area/hellscape/interior/caves/broodmother)
+/obj/structure/interactive/misc/mirror/cracked/chargen{
+	pixel_x = 32
+	},
+/obj/structure/interactive/misc/sink{
+	dir = 4;
+	icon_state = "sink"
+	},
+/turf/simulated/floor/tile/dark,
+/area/hellscape/interior/rev)
 "hJ" = (
 /mob/living/advanced/npc/ashwalker/assassin{
-	icon_state = "directional";
-	dir = 4
+	dir = 4;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/ashwalker_village)
@@ -1786,8 +1805,8 @@
 /area/hellscape/interior/syndicate/aux)
 "hR" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 4
+	dir = 4;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal/reinforced/syndicate,
 /area/hellscape/interior/syndicate/aux)
@@ -1833,8 +1852,8 @@
 /area/hellscape/interior/pirate_landing)
 "ib" = (
 /mob/living/advanced/npc/pirate_crew/ranged{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/wood/boat,
 /area/hellscape/interior/pirate_landing)
@@ -1871,8 +1890,8 @@
 /area/hellscape/exterior/jungle/north)
 "ii" = (
 /mob/living/advanced/npc/pirate_crew/magic{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/wood/dock,
 /area/hellscape/interior/pirate_landing)
@@ -1898,15 +1917,15 @@
 /area/hellscape/interior/pirate_landing)
 "io" = (
 /mob/living/advanced/npc/unique/pirate_mate{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/wood/boat,
 /area/hellscape/interior/pirate_landing)
 "ip" = (
 /mob/living/advanced/npc/pirate_crew/melee{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/wood/boat,
 /area/hellscape/interior/pirate_landing)
@@ -1920,8 +1939,8 @@
 /area/hellscape/interior/pirate_landing)
 "is" = (
 /mob/living/advanced/npc/unique/pirate_captain{
-	icon_state = "directional";
-	dir = 1
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/wood/boat,
 /area/hellscape/interior/pirate_landing)
@@ -2097,8 +2116,8 @@
 /area/hellscape/interior/caves/lava_lake)
 "jf" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 1
+	dir = 1;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal/reinforced/syndicate,
 /area/hellscape/interior/syndicate)
@@ -2134,8 +2153,8 @@
 /area/hellscape/exterior/jungle/south)
 "jn" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 4
+	dir = 4;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal/reinforced/syndicate,
 /area/hellscape/interior/syndicate)
@@ -2210,8 +2229,8 @@
 /area/hellscape/interior/caves/hellchamber)
 "jE" = (
 /obj/structure/interactive/computer/console/remote_flight/charlie{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/plating,
 /area/hellscape/interior/caves/hellchamber)
@@ -2243,8 +2262,8 @@
 /area/hellscape/exterior/jungle/south)
 "jJ" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 8
+	dir = 8;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal/reinforced/syndicate,
 /area/hellscape/interior/syndicate)
@@ -2443,8 +2462,8 @@
 /area/hellscape/exterior/jungle/south)
 "kA" = (
 /mob/living/advanced/npc/syndicate/quadruple{
-	icon_state = "directional";
-	dir = 1
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/tile/dark/er,
 /area/hellscape/interior/syndicate)
@@ -2529,8 +2548,8 @@
 /area/hellscape/interior/caves/watersource)
 "kR" = (
 /mob/living/advanced/npc/syndicate/double{
-	icon_state = "directional";
-	dir = 1
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/hellscape/interior/syndicate)
@@ -2548,8 +2567,8 @@
 /area/hellscape/interior/syndicate)
 "kU" = (
 /obj/decal/hazard/black/corner{
-	icon_state = "corner";
-	dir = 1
+	dir = 1;
+	icon_state = "corner"
 	},
 /obj/structure/interactive/lighting/fixture/tube/syndicate{
 	dir = 1
@@ -2568,22 +2587,22 @@
 /area/hellscape/interior/caves/watersource)
 "kX" = (
 /obj/decal/hazard/black{
-	icon_state = "line";
-	dir = 8
+	dir = 8;
+	icon_state = "line"
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/hellscape/interior/syndicate)
 "kY" = (
 /mob/living/simple/turret/syndicate{
-	icon_state = "active";
-	dir = 4
+	dir = 4;
+	icon_state = "active"
 	},
 /turf/simulated/floor/tile/dark/er,
 /area/hellscape/interior/syndicate)
 "kZ" = (
 /mob/living/simple/turret/syndicate{
-	icon_state = "active";
-	dir = 8
+	dir = 8;
+	icon_state = "active"
 	},
 /turf/simulated/floor/tile/dark/er,
 /area/hellscape/interior/syndicate)
@@ -2605,53 +2624,53 @@
 /area/hellscape/exterior/jungle/south)
 "ld" = (
 /obj/decal/hazard/black{
-	icon_state = "line";
-	dir = 1
+	dir = 1;
+	icon_state = "line"
 	},
 /obj/structure/interactive/atmospherics/fan,
 /turf/simulated/floor/tile/dark/er,
 /area/hellscape/interior/syndicate)
 "le" = (
 /obj/decal/hazard/black/corner{
-	icon_state = "corner";
-	dir = 4
+	dir = 4;
+	icon_state = "corner"
 	},
 /obj/structure/interactive/lighting/fixture/tube/syndicate,
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/hellscape/interior/syndicate)
 "lf" = (
 /obj/structure/interactive/barricade{
-	icon_state = "metal";
-	dir = 1
+	dir = 1;
+	icon_state = "metal"
 	},
 /turf/simulated/floor/tile/dark/er,
 /area/hellscape/interior/syndicate)
 "lg" = (
 /obj/structure/interactive/barricade{
-	icon_state = "metal";
-	dir = 1
+	dir = 1;
+	icon_state = "metal"
 	},
 /mob/living/advanced/npc/syndicate/double{
-	icon_state = "directional";
-	dir = 1
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/tile/dark/er,
 /area/hellscape/interior/syndicate)
 "lh" = (
 /mob/living/advanced/npc/syndicate/triple{
-	icon_state = "directional";
-	dir = 1
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/hellscape/interior/syndicate)
 "li" = (
 /obj/structure/interactive/barricade{
-	icon_state = "metal";
-	dir = 1
+	dir = 1;
+	icon_state = "metal"
 	},
 /mob/living/advanced/npc/syndicate/double{
-	icon_state = "directional";
-	dir = 1
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/hellscape/interior/syndicate)
@@ -2827,8 +2846,8 @@
 /area/hellscape/interior/syndicate)
 "lT" = (
 /mob/living/advanced/npc/syndicate/triple{
-	icon_state = "directional";
-	dir = 4
+	dir = 4;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/hellscape/interior/syndicate)
@@ -3785,15 +3804,15 @@
 /area/hellscape/interior/caves/ancient)
 "pP" = (
 /mob/living/advanced/npc/pirate_crew/melee{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/colored/sand/underwater,
 /area/hellscape/interior/pirate_landing)
 "pQ" = (
 /mob/living/advanced/npc/pirate_crew/melee{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/colored/sand/beach,
 /area/hellscape/interior/pirate_landing)
@@ -4035,8 +4054,8 @@
 /area/hellscape/interior/caves/watersource)
 "qT" = (
 /obj/decal/poster/syndicate{
-	icon_state = "";
-	dir = 4
+	dir = 4;
+	icon_state = ""
 	},
 /turf/simulated/wall/dark,
 /area/hellscape/interior/syndicate/aux)
@@ -4071,8 +4090,9 @@
 /turf/simulated/floor/cave_dirt,
 /area/hellscape/interior/caves/watersource)
 "ra" = (
-/turf/simulated/wall/metal,
-/area/hellscape/interior/caves/watersource)
+/obj/structure/interactive/emitter,
+/turf/simulated/floor/tile/dark,
+/area/hellscape/interior/supermatter)
 "rb" = (
 /turf/simulated/wall/metal,
 /area/hellscape/interior/supermatter)
@@ -4080,16 +4100,17 @@
 /turf/simulated/floor/plating,
 /area/hellscape/exterior/jungle/south)
 "rd" = (
-/obj/structure/interactive/lighting/fixture/floor/strong,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/metal,
 /area/hellscape/interior/caves/watersource)
 "re" = (
 /turf/simulated/floor/tile/dark,
 /area/hellscape/interior/supermatter)
 "rf" = (
-/obj/structure/interactive/emitter,
-/turf/simulated/floor/tile/dark,
-/area/hellscape/interior/supermatter)
+/obj/structure/interactive/misc/mirror/cracked/chargen{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tile/morphing/red/dark,
+/area/hellscape/interior/syndicate)
 "rg" = (
 /obj/marker/map_node,
 /turf/simulated/floor/tile/dark,
@@ -4111,8 +4132,9 @@
 /turf/simulated/floor/tile/dark,
 /area/hellscape/interior/supermatter)
 "rk" = (
+/obj/structure/interactive/door/airlock/station/engineering,
 /turf/simulated/floor/plating,
-/area/hellscape/interior/caves/watersource)
+/area/hellscape/interior/supermatter)
 "rl" = (
 /obj/marker/spawning/window/extra,
 /turf/simulated/floor/tile/grey,
@@ -4125,31 +4147,34 @@
 /turf/simulated/floor/plating,
 /area/hellscape/interior/supermatter)
 "ro" = (
-/obj/marker/map_node,
-/turf/simulated/floor/plating,
+/obj/structure/interactive/door/airlock/station/engineering,
+/turf/simulated/floor/tile/dark,
 /area/hellscape/interior/caves/watersource)
 "rp" = (
 /obj/marker/supermatter_spawn,
 /turf/simulated/floor/plating,
 /area/hellscape/interior/supermatter)
 "rq" = (
-/obj/structure/interactive/lighting/fixture/tube/station{
-	dir = 8
-	},
-/obj/structure/interactive/emitter{
-	icon_state = "emitter";
-	dir = 8
-	},
-/turf/simulated/floor/tile/dark,
-/area/hellscape/interior/supermatter)
+/obj/item/supply_crate/syndicate,
+/obj/item/supply_crate/syndicate,
+/obj/item/supply_crate/syndicate,
+/obj/item/supply_crate/syndicate,
+/turf/simulated/floor/tile/morphing/red/dark,
+/area/hellscape/interior/syndicate)
 "rr" = (
-/obj/structure/scenery/rocks,
-/turf/simulated/floor/plating,
-/area/hellscape/interior/caves/watersource)
+/obj/structure/interactive/misc/mirror/cracked/chargen{
+	pixel_x = 32
+	},
+/obj/structure/interactive/misc/sink{
+	dir = 4;
+	icon_state = "sink"
+	},
+/turf/simulated/floor/tile/morphing/red/dark,
+/area/hellscape/interior/syndicate)
 "rs" = (
 /obj/structure/interactive/computer/console/remote_flight/delta{
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/plating,
 /area/hellscape/interior/caves/hellchamber)
@@ -4174,12 +4199,17 @@
 /turf/simulated/floor/plating,
 /area/hellscape/exterior/jungle/south)
 "ry" = (
-/obj/structure/interactive/emitter{
-	icon_state = "emitter";
-	dir = 1
-	},
+/obj/structure/interactive/crate/medical,
+/obj/item/defib,
+/obj/item/container/spray/silver_sulfadiazine,
+/obj/item/container/spray/styptic_powder,
+/obj/item/container/medicine/trauma_kit/advanced,
+/obj/item/container/medicine/burn_kit/advanced,
+/obj/item/storage/kit/syndicate/filled,
+/obj/item/container/medicine/burn_kit/advanced,
+/obj/item/container/medicine/trauma_kit/advanced,
 /turf/simulated/floor/tile/dark,
-/area/hellscape/interior/supermatter)
+/area/hellscape/interior/syndicate)
 "rz" = (
 /obj/structure/interactive/supplies,
 /turf/simulated/floor/basalt,
@@ -4387,6 +4417,74 @@
 /obj/structure/interactive/crate/chest/filled,
 /turf/simulated/floor/basalt,
 /area/hellscape/interior/caves/hellchamber)
+"ws" = (
+/obj/marker/map_node,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/caves/watersource)
+"xm" = (
+/obj/structure/interactive/lighting/fixture/floor/strong,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/caves/watersource)
+"yx" = (
+/obj/structure/scenery/rocks,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/caves/watersource)
+"yP" = (
+/obj/structure/interactive/lighting/fixture/tube/station{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"Ck" = (
+/obj/marker/spawning/window/reinforced,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"CI" = (
+/obj/structure/interactive/lighting/fixture/tube/station{
+	dir = 4
+	},
+/obj/structure/interactive/computer/console{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"Ek" = (
+/obj/structure/smooth/table/dark,
+/obj/item/weapon/melee/toolbox/blue,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"FG" = (
+/obj/structure/interactive/emitter{
+	dir = 8;
+	icon_state = "emitter"
+	},
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"NR" = (
+/turf/simulated/floor/plating,
+/area/hellscape/interior/caves/watersource)
+"Ss" = (
+/obj/structure/interactive/emitter{
+	dir = 1;
+	icon_state = "emitter"
+	},
+/turf/simulated/floor/tile/dark,
+/area/hellscape/interior/supermatter)
+"Wi" = (
+/obj/structure/smooth/table/dark,
+/obj/item/weapon/melee/toolbox/red,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"Xw" = (
+/obj/structure/smooth/table/dark,
+/obj/item/weapon/melee/tool/wirecutters,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
+"Zd" = (
+/obj/structure/smooth/table/dark,
+/obj/structure/interactive/computer/console/laptop,
+/turf/simulated/floor/plating,
+/area/hellscape/interior/supermatter)
 
 (1,1,1) = {"
 ja
@@ -10463,7 +10561,7 @@ bn
 bn
 bn
 bn
-bn
+ft
 bd
 cc
 bq
@@ -10720,8 +10818,8 @@ bn
 bn
 bn
 bn
-bn
-bn
+ft
+ft
 bd
 bq
 bh
@@ -10978,7 +11076,7 @@ bn
 bn
 bn
 bn
-bn
+ft
 bd
 ca
 bj
@@ -11235,7 +11333,7 @@ bn
 bn
 bn
 bn
-bn
+ft
 bd
 cc
 bq
@@ -11492,8 +11590,8 @@ bn
 bn
 bn
 bn
-bn
-bn
+ft
+ft
 bd
 bq
 bh
@@ -11749,8 +11847,8 @@ bn
 bn
 bn
 bn
-bn
-bn
+ft
+ft
 bd
 bq
 cz
@@ -12006,8 +12104,8 @@ bn
 bn
 bn
 bn
-bn
-bn
+ft
+ft
 bd
 bq
 bq
@@ -12263,9 +12361,9 @@ bn
 bn
 bn
 bn
-bn
-bn
-bn
+ft
+ft
+ft
 bd
 bq
 bh
@@ -12520,9 +12618,9 @@ bn
 bn
 bn
 bn
-bn
-bn
-bn
+ft
+ft
+ft
 bd
 bq
 bq
@@ -12777,9 +12875,9 @@ bn
 bn
 bn
 bn
-bn
-bn
-bn
+ft
+ft
+ft
 bd
 bg
 bq
@@ -12879,8 +12977,8 @@ kc
 kc
 aa
 ab
-aB
-aB
+bp
+hy
 aY
 aY
 bc
@@ -13034,10 +13132,10 @@ cl
 bn
 bn
 bn
-bn
-bn
-bn
-bn
+ft
+ft
+ft
+ft
 bd
 bi
 bq
@@ -13291,11 +13389,11 @@ bv
 bv
 gW
 gW
-bn
-bn
-bn
-bn
-bn
+ft
+ft
+ft
+ft
+ft
 bg
 bq
 bq
@@ -13549,11 +13647,11 @@ bv
 gW
 gW
 ar
-bn
-bn
-bn
-bn
-bn
+ft
+ft
+ft
+ft
+ft
 bq
 bq
 bq
@@ -14934,11 +15032,11 @@ kb
 kc
 kc
 aa
-aB
 an
-aX
-aZ
-aZ
+fy
+hI
+hI
+hI
 aZ
 bl
 aX
@@ -35689,10 +35787,10 @@ eU
 cd
 eU
 eU
-eU
+fv
 cd
 ar
-cd
+cB
 hq
 eU
 eU
@@ -36208,7 +36306,7 @@ eU
 ar
 eU
 hq
-eU
+fv
 eU
 ar
 eU
@@ -36459,16 +36557,16 @@ eU
 eU
 hq
 eU
-eU
-eU
 fv
+eU
+eU
 eU
 eU
 ar
 eU
 cd
-fv
 eU
+fv
 cd
 ar
 eU
@@ -36711,24 +36809,24 @@ cd
 cd
 eU
 eU
-eU
 cd
-eU
-eU
-eU
-eU
-cd
-eU
-ar
 eU
 eU
 eU
 cd
 eU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
 eU
 eU
+hq
 eU
-eU
+hq
 eU
 eU
 eU
@@ -36968,24 +37066,24 @@ aq
 eU
 eU
 eU
-cd
 eU
 eU
-eU
-cd
 eU
 ar
 eU
-eU
+rb
+rb
+Zd
+Ek
+CI
+Xw
+Wi
+rb
+rb
 eU
 eU
 eU
 cd
-eU
-eU
-hq
-eU
-hq
 eU
 eU
 ar
@@ -37225,24 +37323,24 @@ aq
 aq
 eU
 eU
+cd
 eU
 eU
+eU
+eU
+rb
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rb
 eU
 ar
-eU
-eU
-ar
-cd
-cd
-hq
-eU
-cd
-eU
 ar
 eU
-eU
-eU
-cd
 eU
 eU
 eU
@@ -37482,25 +37580,25 @@ aq
 aq
 aq
 eU
-cd
-eU
-eU
-eU
-eU
-eU
-eU
-eU
-eU
-eU
-cj
-cd
-eU
-ar
-eU
-ar
-ar
-eU
-cd
+xm
+NR
+NR
+NR
+ws
+rb
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rb
+ws
+NR
+NR
+NR
+xm
 eU
 eU
 aq
@@ -37739,25 +37837,25 @@ aq
 aq
 aq
 eU
-eU
-rd
+NR
+rb
+rb
+rb
+rh
+rb
 rk
+rb
+Ck
+Ck
+Ck
+rb
 rk
-rk
+rb
 ro
-rk
-rk
-rk
-rk
-rk
-rk
-rk
-rk
-ro
-rk
-rk
 rd
-eU
+rd
+rd
+NR
 eU
 aq
 aq
@@ -37996,25 +38094,25 @@ aq
 aq
 aq
 aq
-aq
-rk
+NR
 rb
+re
+re
+rg
+re
+re
+rj
+re
+re
+re
+rj
+re
+re
+rg
+re
+re
 rb
-rb
-rh
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rb
-rh
-rb
-rb
-rr
-eU
+yx
 aq
 aq
 aq
@@ -38254,23 +38352,23 @@ aq
 aq
 aq
 aq
-rk
 rb
-rg
-re
-rg
-re
-re
-re
-rj
 re
 re
 re
 re
-rg
+re
+re
+re
+re
+re
+re
+re
+re
+re
+re
 re
 rb
-rk
 aq
 aq
 aq
@@ -38511,7 +38609,6 @@ aq
 aq
 aq
 aq
-aq
 rb
 re
 re
@@ -38519,7 +38616,9 @@ re
 re
 re
 re
+ri
 rg
+ri
 re
 re
 re
@@ -38527,7 +38626,6 @@ re
 re
 re
 rb
-aq
 aq
 aq
 aq
@@ -38768,8 +38866,8 @@ aq
 aq
 aq
 aq
-aq
 rb
+re
 re
 re
 re
@@ -38783,8 +38881,8 @@ re
 re
 re
 re
+re
 rb
-aq
 aq
 aq
 aq
@@ -39025,8 +39123,8 @@ aq
 aq
 aq
 aq
-aq
 rb
+re
 re
 re
 ri
@@ -39040,8 +39138,8 @@ re
 ri
 re
 re
+re
 rb
-aq
 aq
 aq
 aq
@@ -39281,9 +39379,9 @@ aq
 aq
 aq
 aq
-aq
-ra
 rb
+rb
+re
 re
 re
 rb
@@ -39297,9 +39395,9 @@ rb
 rb
 re
 re
+re
 rb
 rb
-aq
 aq
 aq
 aq
@@ -39538,8 +39636,8 @@ aq
 aq
 aq
 aq
-aq
-ra
+rb
+re
 re
 re
 re
@@ -39555,8 +39653,8 @@ rb
 re
 re
 re
+re
 rb
-aq
 aq
 aq
 aq
@@ -39795,9 +39893,9 @@ aq
 aq
 aq
 aq
-aq
+rb
 ra
-rf
+re
 rg
 re
 re
@@ -39809,11 +39907,11 @@ rm
 rl
 re
 re
+re
 rg
 re
-ry
+Ss
 rb
-aq
 aq
 aq
 aq
@@ -40052,8 +40150,8 @@ aq
 aq
 aq
 aq
-aq
-ra
+rb
+re
 re
 re
 re
@@ -40069,8 +40167,8 @@ rb
 re
 re
 re
+re
 rb
-aq
 aq
 aq
 aq
@@ -40309,9 +40407,9 @@ aq
 aq
 aq
 aq
-aq
-ra
 rb
+rb
+re
 re
 re
 rb
@@ -40325,9 +40423,9 @@ rb
 rb
 re
 re
+re
 rb
 rb
-aq
 aq
 aq
 aq
@@ -40567,8 +40665,8 @@ aq
 aq
 aq
 aq
-aq
 rb
+re
 re
 re
 rj
@@ -40582,8 +40680,8 @@ re
 rj
 re
 re
+re
 rb
-aq
 aq
 aq
 aq
@@ -40824,7 +40922,6 @@ iC
 aq
 aq
 aq
-aq
 rb
 re
 re
@@ -40839,8 +40936,9 @@ re
 re
 re
 re
+re
+re
 rb
-aq
 aq
 aq
 aq
@@ -41080,26 +41178,26 @@ iC
 iD
 iC
 iC
-iC
-rc
+lc
 rb
-rg
-re
-rg
-re
-re
-re
-rq
-re
-re
 re
 re
 rg
+re
+re
+ri
+re
+re
+re
+ri
+re
+re
+rg
+re
 re
 rb
-rc
-kr
-ks
+aq
+aq
 kr
 ks
 ks
@@ -41337,25 +41435,25 @@ iC
 iD
 iC
 iC
-iD
 rc
 rb
 rb
 rb
 rh
 rb
+rk
 rb
+Ck
+Ck
+Ck
 rb
-rb
-rb
-rb
-rb
+rk
 rb
 rh
 rb
 rb
+rb
 rc
-kr
 kr
 ks
 kr
@@ -41594,25 +41692,25 @@ iC
 iC
 iC
 iC
-iC
 qP
 rc
 rc
 rc
 rv
-rc
-rc
-rc
-rc
-rc
-rc
-rc
-rc
+rb
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rb
 rv
 rc
 rc
+rc
 qP
-iC
 kr
 kr
 kr
@@ -41856,15 +41954,15 @@ iC
 iC
 iC
 iD
-iC
-iD
-iC
-iC
-iC
-iD
-iD
-iC
-iC
+rb
+rm
+rm
+rm
+FG
+rm
+rm
+rm
+rb
 kr
 iD
 iC
@@ -42113,15 +42211,15 @@ iC
 iC
 iC
 iC
-iC
-iC
-iC
-iC
-iC
-iC
-iC
-iC
-jw
+rb
+rb
+rm
+rm
+yP
+rm
+rm
+rb
+rb
 iC
 iC
 iC
@@ -42371,13 +42469,13 @@ iC
 iC
 iD
 iD
-iC
-iC
-iD
-iC
-iC
-iC
-iC
+rb
+rb
+rb
+rb
+rb
+rb
+rb
 iC
 iD
 iC
@@ -42626,7 +42724,7 @@ iD
 iC
 iC
 iI
-iC
+jm
 iC
 iC
 iC
@@ -42636,7 +42734,7 @@ iC
 iC
 iC
 iC
-iC
+jm
 mt
 iC
 iC
@@ -42895,7 +42993,7 @@ iD
 iC
 iC
 iC
-iC
+jw
 iC
 iC
 iC
@@ -43401,11 +43499,11 @@ iC
 iD
 iC
 iC
+jm
 iC
 iC
 iC
-iC
-iC
+jm
 iC
 iD
 iC
@@ -57124,28 +57222,28 @@ cW
 cW
 cW
 jL
-jL
-jL
-jL
-jL
-lr
-lr
-lr
-lr
-lr
-lr
-lr
-lr
-lr
-fy
-lr
-lr
-lr
-lr
-lr
-lr
-fy
-hy
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+bb
+ea
 bs
 bs
 ae
@@ -57383,10 +57481,10 @@ jL
 jL
 jL
 dl
-jL
-jL
-lr
-lr
+bb
+bb
+bb
+bb
 ep
 ep
 ep
@@ -57397,13 +57495,13 @@ ep
 ep
 ep
 ep
-lr
-lr
-lr
-lr
-lr
-lr
-hI
+bb
+bb
+bb
+bb
+bb
+qu
+qN
 ae
 bs
 bs
@@ -57641,8 +57739,8 @@ jL
 jL
 jL
 jL
-jL
-lr
+bb
+bb
 ep
 ep
 ep
@@ -57657,12 +57755,12 @@ ep
 ep
 ep
 ep
-lr
-lr
-fy
-lr
-lr
-lr
+bb
+qu
+je
+qu
+qu
+qu
 bs
 bs
 bs
@@ -57918,10 +58016,10 @@ ep
 ep
 ep
 ep
-lr
-fy
-lr
-lr
+qu
+je
+qu
+qu
 eA
 ae
 bs
@@ -58176,9 +58274,9 @@ ep
 ep
 ep
 ep
-lr
-lr
-lr
+qu
+qu
+qu
 qu
 ae
 aH
@@ -58434,8 +58532,8 @@ lr
 lr
 ep
 ep
-lr
-lr
+qu
+qu
 je
 qu
 qu
@@ -58692,7 +58790,7 @@ lr
 lr
 lr
 lr
-lr
+qu
 qu
 qu
 je
@@ -58949,7 +59047,7 @@ lr
 lr
 lr
 lr
-lr
+qu
 qu
 qu
 qu
@@ -59978,7 +60076,7 @@ lr
 lr
 lr
 lr
-qo
+ep
 qo
 qu
 qu
@@ -60235,7 +60333,7 @@ lr
 lr
 lr
 lr
-qo
+ep
 qo
 qo
 qu
@@ -66640,7 +66738,7 @@ iN
 iN
 gP
 es
-gN
+rq
 lT
 lT
 mb
@@ -66890,7 +66988,7 @@ qs
 qs
 qs
 qu
-es
+jj
 lk
 iT
 iT
@@ -66903,7 +67001,7 @@ iR
 iT
 mh
 es
-iN
+ry
 iU
 iT
 iT
@@ -67147,8 +67245,8 @@ qs
 qs
 qu
 qu
-jj
-iN
+es
+rf
 iT
 iT
 iU
@@ -67405,7 +67503,7 @@ qu
 qu
 qu
 es
-iN
+rf
 iT
 iT
 iT
@@ -67662,7 +67760,7 @@ qu
 qu
 qu
 es
-iN
+rf
 iT
 iT
 iT
@@ -69211,9 +69309,9 @@ iN
 iN
 jf
 gP
-gN
-gN
-gN
+rr
+rr
+rr
 pj
 pl
 jJ
@@ -69468,9 +69566,9 @@ jJ
 jJ
 es
 es
-jJ
-jJ
-jJ
+es
+es
+es
 es
 es
 lp


### PR DESCRIPTION
# What this PR does
Adds cracked Mirrors to Rev and Syndicate bases

Smoothes a few areas for more precise locations on pinpointers/death implants/cheese crafting.

Fixes a pathing bug at the supermatter and makes the structure a bit wider to give the AI cover on the doors when pathing, where previously they tried to walk through the wall to get to the closest node.

# Why it should be added to the game
QOL very good yes