### PR TITLE
dye dye dye dye dye dye dye dye dye dye dye dye dye

### DIFF
--- a/code/_core/obj/item/clothing/back/storage/backpack/poly.dm
+++ b/code/_core/obj/item/clothing/back/storage/backpack/poly.dm
@@ -1,5 +1,6 @@
 /obj/item/clothing/back/storage/backpack/poly
 	icon = 'icons/obj/item/clothing/back/backpack/poly.dmi'
+	dyeable = TRUE
 	polymorphs = list(
 		"body" = COLOR_WHITE,
 		"straps" = COLOR_WHITE,

--- a/code/_core/obj/item/clothing/back/storage/duffle/poly.dm
+++ b/code/_core/obj/item/clothing/back/storage/duffle/poly.dm
@@ -1,5 +1,6 @@
 /obj/item/clothing/back/storage/dufflebag/poly
 	icon = 'icons/obj/item/clothing/back/dufflebag/poly.dmi'
+	dyeable = TRUE
 	polymorphs = list(
 		"body" = COLOR_WHITE,
 		"detail" = COLOR_WHITE,

--- a/code/_core/obj/item/clothing/back/storage/satchel/poly.dm
+++ b/code/_core/obj/item/clothing/back/storage/satchel/poly.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/back/storage/satchel/poly
 	name = "satchel"
 	icon = 'icons/obj/item/clothing/back/satchel/poly.dmi'
+	dyeable = TRUE
 	polymorphs = list(
 		"body" = COLOR_WHITE,
 		"straps" = COLOR_WHITE,

--- a/code/_core/obj/item/dying.dm
+++ b/code/_core/obj/item/dying.dm
@@ -15,14 +15,29 @@
 		return FALSE
 
 	var/choice
-
+	var/mob/E = caller
 	if(length(polymorphs))
+		if(E.attack_flags & CONTROL_MOD_ALT && D.type == /obj/item/slime_core/custom)
+			choice = input("What do you want to copy?","Dye Selection") as null|anything in polymorphs
+			if(choice)
+				INTERACT_CHECK_NO_DELAY(src)
+				INTERACT_CHECK_NO_DELAY(D)
+				D.color = polymorphs[choice]
+				caller.to_chat(span("notice","You copy \the color from \the [src.name]."))
+				return TRUE
+			else return FALSE
 		choice = input("What do you want to dye?","Dye Selection") as null|anything in polymorphs
 		if(choice)
 			INTERACT_CHECK_NO_DELAY(src)
 			INTERACT_CHECK_NO_DELAY(D)
 			polymorphs[choice] = blend_colors(polymorphs[choice] ? polymorphs[choice] : "#FFFFFF",dye_color,dye_strength)
 	else
+		if(E.attack_flags & CONTROL_MOD_ALT && D.type == /obj/item/slime_core/custom)
+			INTERACT_CHECK_NO_DELAY(src)
+			INTERACT_CHECK_NO_DELAY(D)
+			D.color = color
+			caller.to_chat(span("notice","You copy \the color from \the [src.name]."))
+			return TRUE
 		choice = input("Are you sure you want to dye \the [src.name]?","Dye Selection") as null|anything in list("Yes","No","Cancel")
 		if(choice == "Yes")
 			INTERACT_CHECK_NO_DELAY(src)

--- a/code/_core/obj/item/dying.dm
+++ b/code/_core/obj/item/dying.dm
@@ -15,29 +15,13 @@
 		return FALSE
 
 	var/choice
-	var/mob/E = caller
 	if(length(polymorphs))
-		if(E.attack_flags & CONTROL_MOD_ALT && D.type == /obj/item/slime_core/custom)
-			choice = input("What do you want to copy?","Dye Selection") as null|anything in polymorphs
-			if(choice)
-				INTERACT_CHECK_NO_DELAY(src)
-				INTERACT_CHECK_NO_DELAY(D)
-				D.color = polymorphs[choice]
-				caller.to_chat(span("notice","You copy \the color from \the [src.name]."))
-				return TRUE
-			else return FALSE
 		choice = input("What do you want to dye?","Dye Selection") as null|anything in polymorphs
 		if(choice)
 			INTERACT_CHECK_NO_DELAY(src)
 			INTERACT_CHECK_NO_DELAY(D)
 			polymorphs[choice] = blend_colors(polymorphs[choice] ? polymorphs[choice] : "#FFFFFF",dye_color,dye_strength)
 	else
-		if(E.attack_flags & CONTROL_MOD_ALT && D.type == /obj/item/slime_core/custom)
-			INTERACT_CHECK_NO_DELAY(src)
-			INTERACT_CHECK_NO_DELAY(D)
-			D.color = color
-			caller.to_chat(span("notice","You copy \the color from \the [src.name]."))
-			return TRUE
 		choice = input("Are you sure you want to dye \the [src.name]?","Dye Selection") as null|anything in list("Yes","No","Cancel")
 		if(choice == "Yes")
 			INTERACT_CHECK_NO_DELAY(src)

--- a/code/_core/obj/item/slime_core/_slime_core.dm
+++ b/code/_core/obj/item/slime_core/_slime_core.dm
@@ -52,7 +52,7 @@
 /obj/item/slime_core/custom/click_self(var/mob/caller)
 	INTERACT_CHECK
 	INTERACT_DELAY(10)
-	var/choice = input("What would you like the color to be?") as color|null
+	var/choice = input("What would you like the color to be?", null, color) as color|null
 	if(choice)
 		color = choice
 		update_sprite()

--- a/code/_core/obj/item/slime_core/_slime_core.dm
+++ b/code/_core/obj/item/slime_core/_slime_core.dm
@@ -46,6 +46,7 @@
 
 /obj/item/slime_core/custom
 	name = "custom slime core"
+	desc_extended = "Can change into any color. Alt-clicking other items copies the color instead."
 	value = 1000
 	alpha = 255
 

--- a/code/_core/obj/item/slime_core/_slime_core.dm
+++ b/code/_core/obj/item/slime_core/_slime_core.dm
@@ -50,6 +50,28 @@
 	value = 1000
 	alpha = 255
 
+/obj/item/slime_core/custom/click_on_object(var/mob/caller as mob,var/atom/object,location,control,params)
+	var/mob/E = caller
+	var/obj/item/O = object
+	if(E.attack_flags & CONTROL_MOD_ALT && O.dyeable)
+		var/choice
+		if(O.polymorphs)
+			choice = input("What do you want to copy?","Dye Selection") as null|anything in O.polymorphs
+			if(choice)
+				INTERACT_CHECK_NO_DELAY(src)
+				INTERACT_CHECK_NO_DELAY(object)
+				color = O.polymorphs[choice]
+				caller.to_chat(span("notice","You copy \the color from \the [O.name]."))
+				return TRUE
+			else return TRUE
+		else
+			INTERACT_CHECK_NO_DELAY(src)
+			INTERACT_CHECK_NO_DELAY(object)
+			color = O.color
+			caller.to_chat(span("notice","You copy \the color from \the [O.name]."))
+			return TRUE
+	. = ..()
+
 /obj/item/slime_core/custom/click_self(var/mob/caller)
 	INTERACT_CHECK
 	INTERACT_DELAY(10)


### PR DESCRIPTION
# What this PR does
-fixes the "Current" color preview of the custom slime core (also fixing where the color choice is on opening it)
-adds the ability to COPY the color of an item onto the custom core with alt clicking for easier coloring
-adds a description to da core
-makes the satchel/backpack/duffles dyable (:
# Why it should be added to the game
![coolphoto](https://user-images.githubusercontent.com/9487319/110172634-b7df6180-7dfd-11eb-89a7-a47d81e420fe.png)
