### PR TITLE
fishing LUCK time

### DIFF
--- a/code/_core/obj/item/fishing/rod.dm
+++ b/code/_core/obj/item/fishing/rod.dm
@@ -189,9 +189,6 @@
 
 	INTERACT_CHECK
 
-	if(compact)
-		caller.to_chat(span("notice","Extend your fishing rod first!"))
-		return TRUE
 	if(object.plane >= PLANE_HUD)
 		return ..()
 
@@ -245,6 +242,9 @@
 			return TRUE
 
 	if(istype(object,/turf/simulated/hazard/))
+		if(compact)
+			caller.to_chat(span("notice","Extend your fishing rod first!"))
+			return TRUE
 		var/turf/simulated/hazard/H = object
 		if(!H.fishing_rewards)
 			return TRUE
@@ -291,6 +291,8 @@
 /obj/item/fishing/rod/telescopic/click_self(var/mob/caller)
 	INTERACT_CHECK
 	INTERACT_DELAY(5)
+	if(fishing_turf)
+		return TRUE
 	compact = !compact
 	update_sprite()
 	play_sound('sound/items/drop/accessory.ogg',get_turf(src),range_max=VIEW_RANGE*0.2)

--- a/code/_core/obj/item/fishing/rod.dm
+++ b/code/_core/obj/item/fishing/rod.dm
@@ -44,12 +44,11 @@
 	LOADATOM("line")
 	LOADATOM("bait")
 	
-/obj/item/fishing/rod/update_value()
-	value = initial(value)
-	if(line) value += line.value
-	if(lure) value += lure.value
-	if(bait) value += bait.value
-	return TRUE
+/obj/item/fishing/rod/get_value()
+	. = ..()
+	if(line) . += line.get_value()
+	if(lure) . += lure.get_value()
+	if(bait) . += bait.get_value()
 
 /obj/item/fishing/rod/update_overlays()
 	. = ..()
@@ -85,7 +84,6 @@
 		caller.to_chat(span("notice","You remove \the [object_removed.name]."))
 		object_removed.drop_item(get_turf(src))
 		I.add_object(object_removed)
-		update_value()
 		return TRUE
 
 	if(is_item(object))
@@ -101,7 +99,6 @@
 			line = P
 			P.drop_item(src)
 			update_sprite()
-			update_value()
 			return TRUE
 
 		if(istype(object,/obj/item/fishing/lure/))
@@ -115,7 +112,6 @@
 
 			lure = P
 			P.drop_item(src)
-			update_value()
 			return TRUE
 
 		if(istype(object,/obj/item/fishing/bait/))
@@ -129,7 +125,6 @@
 
 			bait = P
 			P.drop_item(src)
-			update_value()
 			return TRUE
 
 	return ..()

--- a/code/_core/obj/item/fishing/rod.dm
+++ b/code/_core/obj/item/fishing/rod.dm
@@ -9,6 +9,7 @@
 	drop_sound = 'sound/items/drop/scrap.ogg'
 
 	size = SIZE_3
+	can_rename = TRUE
 
 	weight = 5
 

--- a/code/_core/obj/item/fishing/rod.dm
+++ b/code/_core/obj/item/fishing/rod.dm
@@ -190,11 +190,9 @@
 	if(fishing_turf)
 		if(snagged_fish) //Caught something!
 			var/mob/living/C = caller // here comes the luck calc
-			var/lucktotal = clamp((C.get_attribute_level(ATTRIBUTE_LUCK) + (src.luck/2)- 75),1,75)	//base player+rod is 0 unless boosted, item luck affects it by half
-			var/luckroll = rand(0,100)
 			var/luckmod
-			if(luckroll <= lucktotal)
-				luckmod = (rand(1,5)/10)
+			if(luck(list(C,src),25))
+				luckmod = (rand(1,5)*0.1)
 			var/score_add = (20/snagged_fish)
 			var/score_mul = 1.5 - ((world.time - catch_time)/snagged_fish) + luckmod
 			var/loot/L = LOOT(fishing_turf.fishing_rewards)


### PR DESCRIPTION
# What this PR does
-fixes the value of fishing rods to take accesories in count
-luck now impacts fishing!
-fixed telescopic rod "extend now!!!" shenanigans on clicking literally anything
 ~~there is a chance on catch to get a buff giving better loot, affected from attribute and item luck
the chances for the trigger are MINIMUM 1% and MAXIMUM 75%, however item luck is half as good as attribute luck, so basically each points of luck above 50 give you a 1% more to trigger it, and each clover gives 0.5%~~
changed to be 25% chance to trigger luck at 100luck+50luck on rod
sidenote: putting clovers on actual accessories like bobbers and so on does nothing (so only upgrade the ROD), cant disable the ability to do so either yet as there is no way to "blacklist" items from tempering at the moment
# Why it should be added to the game
![fisheing](https://user-images.githubusercontent.com/9487319/110221141-c3e52500-7eca-11eb-8ec7-26a8eaf7fd9a.png)
