### PR TITLE
Herald Buff

### DIFF
--- a/code/_core/datum/class/npc/herald.dm
+++ b/code/_core/datum/class/npc/herald.dm
@@ -8,7 +8,7 @@
 	//Luck untouched
 	//10 total attributes
 	attributes = list(
-		ATTRIBUTE_STRENGTH = 50,
+		ATTRIBUTE_STRENGTH = 65,
 		ATTRIBUTE_VITALITY = 75,
 		ATTRIBUTE_FORTITUDE = 25,
 
@@ -38,7 +38,7 @@
 
 		SKILL_MELEE = 5,
 		//SKILL_BLOCK = 50,
-		SKILL_UNARMED = 50,
+		SKILL_UNARMED = 65,
 		SKILL_PRAYER = 5,
 
 		SKILL_MEDICINE = 5,

--- a/code/_core/mob/living/simple/herald.dm
+++ b/code/_core/mob/living/simple/herald.dm
@@ -10,7 +10,7 @@
 
 	boss_loot = /loot/lavaland/herald
 
-	health_base = 1500
+	health_base = 5000
 	stamina_base = 2000
 	mana_base = 100
 


### PR DESCRIPTION
# What this PR does
Increases herald's hp from 1500 to 5000
increases herald's strength and unarmed from 50 to 65
# Why it should be added to the game
The Herald currently poses no threat for the potential reward of a double 4 leaf clover. The health and slight damage increase should prevent him from getting killed in seconds without doing at least some damage.