### PR TITLE
Description fix for stockers and maybe other items

### DIFF
--- a/code/_core/obj/item/clothing/head/helmet/full/nanotrasen.dm
+++ b/code/_core/obj/item/clothing/head/helmet/full/nanotrasen.dm
@@ -32,7 +32,7 @@
 
 
 /obj/item/clothing/head/helmet/full/nanotrasen/medium
-	name = "medium Jaeger hemlet"
+	name = "medium Jaeger helmet"
 	polymorphs = list(
 		"helmet_medium" = "#FFFFFF",
 		"visor_medium" = "#FFFFFF"
@@ -57,7 +57,7 @@
 
 
 /obj/item/clothing/head/helmet/full/nanotrasen/heavy
-	name = "heavy Jaeger hemlet"
+	name = "heavy Jaeger helmet"
 	polymorphs = list(
 		"helmet_heavy" = "#FFFFFF",
 		"visor_heavy" = "#FFFFFF"

--- a/code/_core/obj/item/clothing/overwear/coat/vest.dm
+++ b/code/_core/obj/item/clothing/overwear/coat/vest.dm
@@ -115,7 +115,7 @@
 	)
 
 /obj/item/clothing/overwear/coat/vest/poly/pockets_only
-	name = "webbing pcokets"
+	name = "webbing pockets"
 
 	polymorphs = list(
 		"pockets" = COLOR_BLACK

--- a/code/_core/obj/structure/interactive/restocker.dm
+++ b/code/_core/obj/structure/interactive/restocker.dm
@@ -26,7 +26,7 @@
 /obj/structure/interactive/restocker/ammo
 	name = "portable magazine restocker"
 	desc = "Warning: Does not contain literature."
-	desc_extended = "A machine that automatically fills magazines inserted into the machine with the magazine's purchased ammo type."
+	desc_extended = "A machine that automatically fills magazines inserted into the machine with cheap surplus rounds."
 	icon = 'icons/obj/structure/vending.dmi'
 	icon_state = "gear2_ammo"
 	anchored = FALSE


### PR DESCRIPTION
# What this PR does
Makes the existence of surplus ammo more noticeable hopefully
Maybe I'll not be lazy and give a description to surplus rounds themselves that reflects their weakness
If anyone gives me items that have incorrect/no description that kinda needs them, Ill update the PR to add those.
# Why it should be added to the game
descriptions should be accurate