### PR TITLE
make station-side afk farming less rampant

### DIFF
--- a/code/_core/mob/living/experience.dm
+++ b/code/_core/mob/living/experience.dm
@@ -67,6 +67,9 @@
 /mob/living/get_xp_multiplier()
 	if(master)
 		return 0
+	var/turf/srcTurf = get_turf(src)
+	if(srcTurf.z != Z_LEVEL_MISSION)
+		return 0
 	return 1
 
 /mob/living/proc/initialize_attributes()


### PR DESCRIPTION
# What this PR does
default mobs, if they are station-side, they do not reward exp.

# Why it should be added to the game
people are abusing stamina damage on mobs to reach really fast farming with no risk.
Afk farming (on the station) should be the dummies, which are slow, not some goblin.