### PR TITLE
no more wall totems, no more bullet hits from summons

### DIFF
--- a/code/_core/mob/living/simple/goblin_king.dm
+++ b/code/_core/mob/living/simple/goblin_king.dm
@@ -95,6 +95,8 @@
 			/obj/structure/totem/sacred_flame, /obj/structure/totem/stamina_deal, /obj/structure/totem/health_heal,
 			/obj/structure/totem/projectile/ice_crystal, /obj/structure/totem/projectile/fireball, /obj/structure/totem/projectile/lightning_bolt)
 		var/turf/turf_to_spawn = get_step(T, pick(NORTH,SOUTH,EAST,WEST))
+		if(is_wall(turf_to_spawn))
+			continue
 		var/obj/structure/totem/summoned_totem = new totem_to_spawn(turf_to_spawn)
 		summoned_totem.affecting_faction = loyalty_tag
 		summoned_totem.ranged_limited = FALSE

--- a/code/_core/obj/item/weapon/ranged/magic/tomes/summon/totem/_totem.dm
+++ b/code/_core/obj/item/weapon/ranged/magic/tomes/summon/totem/_totem.dm
@@ -20,7 +20,9 @@
 /obj/item/weapon/ranged/magic/tome/summon/totem/on_projectile_hit(obj/projectile/P, atom/hit_atom)
 	if(istype(P,/obj/projectile/bullet/thrown/))
 		return ..()
-	var/obj/structure/totem/summoned_totem = new totem_to_spawn(P.previous_loc)
+	if(is_wall(hit_atom))
+		return ..()
+	var/obj/structure/totem/summoned_totem = new totem_to_spawn(get_turf(hit_atom))
 	if(is_living(P.owner))
 		var/mob/living/livingOwner = P.owner
 		if(livingOwner.totem)

--- a/code/_core/obj/projectile/magic.dm
+++ b/code/_core/obj/projectile/magic.dm
@@ -212,6 +212,7 @@
 	steps_allowed = 6
 	hit_target_turf = TRUE
 	lifetime = SECONDS_TO_DECISECONDS(2)
+	impact_effect_turf = null
 
 /obj/projectile/magic/blackflame
 	name = "blackflame"


### PR DESCRIPTION
# What this PR does
totems can no longer spawn in walls
summons (both totem and mob) no longer make a bullet impact

# Why it should be added to the game
can't just clear rooms from outside through the wall with totems now
it is magic, it shouldn't leave a bullet hole