### PR TITLE
Totems: An Owner Lost

### DIFF
--- a/code/_core/obj/structure/totem.dm
+++ b/code/_core/obj/structure/totem.dm
@@ -31,6 +31,9 @@
 	return ..()
 
 /obj/structure/totem/think()
+	if(owner?.dead)
+		qdel(src)
+		return FALSE
 	if(world.time >= totem_remove_time)
 		qdel(src)
 		return FALSE


### PR DESCRIPTION
# What this PR does
when an owner dies, totems will die

# Why it should be added to the game
goblin king solution as well as stopping post-death player cheese