### PR TITLE
paper bag altclick fix

### DIFF
--- a/code/_core/obj/item/clothing/head/helmet/full/paper_bag.dm
+++ b/code/_core/obj/item/clothing/head/helmet/full/paper_bag.dm
@@ -43,7 +43,7 @@
 /obj/item/clothing/head/helmet/full/paperbag/click_self(var/mob/caller)
 
 	var/mob/C = caller
-	if(C.attack_flags & CONTROL_MOD_ALT)
+	if(C.attack_flags & CONTROL_MOD_ALT && istype(src.loc,/obj/hud/inventory/organs/))
 		INTERACT_CHECK
 		var/choice = input("What do you want to change on \the [src.name]?","Design Selection") as null|anything in list("Logo","Background")
 		if(choice == "Logo")


### PR DESCRIPTION
# What this PR does
-changes the paper bag logo edit menu to only appear when its in your hands, so now they can be alt clicked in the inventory like other containers

# Why it should be added to the game
this .dm is my fucking baby