### PR TITLE
Fixes the wrong type of shotgun ammo being restocked into 20g buckshot drums

### DIFF
--- a/code/_core/obj/item/magazine/autoshotgun.dm
+++ b/code/_core/obj/item/magazine/autoshotgun.dm
@@ -34,6 +34,7 @@
 /obj/item/magazine/shotgun_auto/buckshot
 	name = "\improper 20g bulldog magazine (buckshot)"
 	ammo = /obj/item/bullet_cartridge/shotgun_20/buckshot
+	ammo_surplus = /obj/item/bullet_cartridge/shotgun_20/buckshot/surplus
 
 /obj/item/magazine/shotgun_auto/slug
 	name = "\improper 20g bulldog magazine magazine (slug)"


### PR DESCRIPTION
# What this PR does
Does exactly what is says on the tin, makes 20g buckshot drums actually get restocked with buckshot instead of slugs.

# Why it should be added to the game
please fix my gun