### PR TITLE
Zoom is now 'hold to set direction'

### DIFF
--- a/code/_core/client/_client.dm
+++ b/code/_core/client/_client.dm
@@ -37,6 +37,7 @@ var/global/list/all_clients = list() //Assoc list
 
 	var/disable_controls = FALSE
 
+	var/zoom_held = FALSE
 	var/is_zoomed = 0x0 //Takes a dir as a value.
 
 	var/next_allowed_topic = -1

--- a/code/_core/client/camera.dm
+++ b/code/_core/client/camera.dm
@@ -47,7 +47,7 @@
 	if(object && examine_mode)
 		mob.examine_overlay.maptext = "[object]"
 
-	if(is_zoomed && mob && isturf(location))
+	if(zoom_held && mob && isturf(location))
 		var/zoom_mul = 1
 		var/real_angle = get_angle(mob,location) + 90
 		var/real_dir = angle2dir(real_angle)

--- a/code/_core/datum/macros/_macros.dm
+++ b/code/_core/datum/macros/_macros.dm
@@ -109,6 +109,7 @@
 			if((owner.mob.attack_flags & CONTROL_MOD_BLOCK) || owner.is_zoomed)
 				owner.is_zoomed = 0x0
 			else
+				owner.zoom_held = TRUE
 				owner.is_zoomed = owner.mob.dir
 
 	return TRUE
@@ -163,7 +164,7 @@
 		if("kick")
 			owner.mob.attack_flags &= ~CONTROL_MOD_KICK
 		if("zoom")
-			//Do nothing
+			owner.zoom_held = FALSE
 		if("say")
 			owner.mob.say()
 		else


### PR DESCRIPTION
# What this PR does
Makes the zoom not a toggle, but a hold-to-set.

# Why it should be added to the game
Zoom improved, no longer absolutely uncontrollable and absolutely based.