### PR TITLE
Customisable proximity

### DIFF
--- a/code/_core/obj/item/trigger/proximity.dm
+++ b/code/_core/obj/item/trigger/proximity.dm
@@ -1,12 +1,14 @@
 /obj/item/device/proximity
 	name = "proximity sensor"
 	desc = "Tick tock."
-	desc_extended = "A simple proximity sensor triggers when any living creature in a 2 unit radius enters its sphere. Has a set delay."
+	desc_extended = "A simple proximity sensor that triggers when any living creature in a set radius enters its sphere. The range can be set with a multitool, and the activation timer with an integrated wheel. Has a set delay."
 	icon_state = "motion"
 
 	var/time_set = 50
 	var/time_min = 0
 	var/time_max = 300
+
+	var/range_set = 2
 
 	var/spam_fix_time = 0
 
@@ -21,10 +23,12 @@
 /obj/item/device/proximity/save_item_data(var/save_inventory = TRUE)
 	. = ..()
 	SAVEVAR("time_set")
+	SAVEVAR("range_set")
 
 /obj/item/device/proximity/load_item_data_post(var/mob/living/advanced/player/P,var/list/object_data)
 	. = ..()
 	LOADVAR("time_set")
+	LOADVAR("range_set")
 
 /obj/item/device/proximity/click_self(var/mob/caller)
 	INTERACT_CHECK
@@ -55,7 +59,7 @@
 				play_sound('sound/weapons/timer/beep.ogg',T,range_max=VIEW_RANGE*0.25)
 
 		if(time_set < 0 && !(time_set % 10))
-			for(var/mob/living/L in view(2,get_turf(src)))
+			for(var/mob/living/L in view(range_set,get_turf(src)))
 				loc.trigger(last_interacted,src,-1,-1)
 				play_sound('sound/weapons/timer/beep.ogg',get_turf(src),range_max=VIEW_RANGE*0.5)
 				flick("motion_trigger",src)
@@ -88,3 +92,25 @@
 	spam_fix_time = world.time + 20
 
 	return TRUE
+
+/obj/item/device/proximity/clicked_on_by_object(var/mob/caller,var/atom/object,location,control,params)
+
+	if(istype(object,/obj/item/weapon/melee/tool/multitool))
+		INTERACT_CHECK
+		INTERACT_CHECK_OBJECT
+		INTERACT_DELAY(1)
+
+		if(range_set > 0)
+			range_set -= 1
+			caller.to_chat(span("notice","You change \the [src.name]'s range to [range_set] tiles..."))
+			return TRUE
+		range_set = 2
+		caller.to_chat(span("notice","You change \the [src.name]'s range to [range_set] tiles..."))
+		return TRUE
+
+	return ..()
+
+/obj/item/device/proximity/get_examine_list(var/mob/examiner)
+	. = ..()
+	. += div("notice","The timer is set at [time_set] deciseconds.")
+	. += div("notice","The range is set at [range_set] tiles.")

--- a/code/_core/obj/item/trigger/proximity.dm
+++ b/code/_core/obj/item/trigger/proximity.dm
@@ -69,7 +69,7 @@
 
 /obj/item/device/proximity/mouse_wheel_on_object(var/mob/caller,delta_x,delta_y,location,control,params)
 
-	var/fixed_delta = delta_y ? 1 : -1
+	var/fixed_delta = delta_y > 0 ? 1 : -1
 
 	if(time_set >= 15)
 		fixed_delta = round(fixed_delta*5,5)


### PR DESCRIPTION
# What this PR does

The proximity scanner's range can now be set with a multitool between 2 and 0 for extra funny landmines.

# Why it should be added to the game

Mines will now explode exactly when you want them for maximum damage against mobs, no more glancing damage from mines exploding two tiles away :)