### PR TITLE
Adds Descriptions (Both desc and desc_extended) to walls

### DIFF
--- a/burgerstation.dme
+++ b/burgerstation.dme
@@ -1845,6 +1845,7 @@
 #include "code\_core\obj\vehicle\_vehicle.dm"
 #include "code\_core\obj\vehicle\car.dm"
 #include "code\_core\turf\_turf.dm"
+#include "code\_core\turf\changeturf.dm"
 #include "code\_core\turf\space.dm"
 #include "code\_core\turf\simulated\_simulated.dm"
 #include "code\_core\turf\simulated\floor\_floor.dm"

--- a/burgerstation.dme
+++ b/burgerstation.dme
@@ -1845,7 +1845,6 @@
 #include "code\_core\obj\vehicle\_vehicle.dm"
 #include "code\_core\obj\vehicle\car.dm"
 #include "code\_core\turf\_turf.dm"
-#include "code\_core\turf\changeturf.dm"
 #include "code\_core\turf\space.dm"
 #include "code\_core\turf\simulated\_simulated.dm"
 #include "code\_core\turf\simulated\floor\_floor.dm"

--- a/code/_core/turf/simulated/wall/ash.dm
+++ b/code/_core/turf/simulated/wall/ash.dm
@@ -1,6 +1,9 @@
 /turf/simulated/wall/ash
 	name = "ash wall"
 
+	desc = "Gotta catch em all"
+	desc_extended = "A solid wall of ash."
+
 	real_icon = 'icons/turf/floor/ash.dmi'
 	real_icon_state = "floor"
 
@@ -29,4 +32,6 @@
 
 /turf/simulated/wall/ash/dark
 	name = "volcanic ash wall"
+	desc = "Gotta catch em all"
+	desc_extended = "A solid wall of volcanic ash."
 	color = "#262626"

--- a/code/_core/turf/simulated/wall/banana.dm
+++ b/code/_core/turf/simulated/wall/banana.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/bananium
 	name = "bananium wall"
+	desc = "HONK"
+	desc_extended = "A wall made of bananium."
 	icon = 'icons/turf/wall/bananium.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE

--- a/code/_core/turf/simulated/wall/boss.dm
+++ b/code/_core/turf/simulated/wall/boss.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/boss
 	name = "necro wall"
+	desc = "Ominous"
+	desc_extended = "A wall made of an unknown material, there are usually powerful enemies nearby."
 	icon = 'icons/turf/wall/boss.dmi'
 	icon_state = "wall"
 	corner_category = "boss"

--- a/code/_core/turf/simulated/wall/brick.dm
+++ b/code/_core/turf/simulated/wall/brick.dm
@@ -1,6 +1,9 @@
 /turf/simulated/wall/brick
 	name = "wall"
 
+	desc = "Like a brick to the head"
+	desc_extended = "A wall made of bricks."
+
 	icon = 'icons/turf/wall/rock_preview.dmi'
 	icon_state = "brick"
 
@@ -14,40 +17,60 @@
 
 /turf/simulated/wall/brick/red
 	color = "#C66B59"
+	desc = "Like a brick to the head"
+	desc_extended = "A wall made of bricks. This one is made of red bricks."
 
 /turf/simulated/wall/brick/red/dark
 	color = "#824439"
+	desc = "Like a brick to the head"
+	desc_extended = "A wall made of bricks. This one is made of dark red bricks."
 
 
 /turf/simulated/wall/brick/sand
 	name = "sandstone wall"
 	color = "#FFC68C"
+	desc = "It gets everywhere"
+	desc_extended = "A wall made of sandstone bricks."
 
 /turf/simulated/wall/brick/sand/ish
 	color = "#9E866E"
+	desc = "Like a brick to the head"
+	desc_extended = "A wall made of bricks. This one is a bit sandy"
 
 /turf/simulated/wall/brick/marble
 	name = "marble wall"
 	color = "#E1DFD2"
+	desc = "Ohh, fancy"
+	desc_extended = "A wall made of marble bricks."
 
 /turf/simulated/wall/brick/chapel
 	name = "chapel wall"
 	color = COLOR_GREY_DARK
+	desc = "In the name of Burger"
+	desc_extended = "A wall made of bricks. This one is part of a chapel."
 
 /turf/simulated/wall/brick/banana
 	name = "banana brick wall"
 	color = "#FFFF00"
+	desc = "HOOOOONK"
+	desc_extended = "A wall made of banana bricks."
 
 /turf/simulated/wall/brick/uranium
 	name = "uranium brick wall"
 	color = COLOR_URANIUM
 	//material = /material/uranium
+	desc = "Radioactive"
+	desc_extended = "A wall made of uranium bricks."
 
 
 /turf/simulated/wall/brick/grey
 	color = "#647064"
+	desc = "Like a brick to the head"
+	desc_extended = "A wall made of bricks. These are grey."
 
 /turf/simulated/wall/brick/grey/dark
 	color = COLOR_GREY_DARK
+	desc = "Like a brick to the head"
+	desc_extended = "A wall made of bricks."
 
 

--- a/code/_core/turf/simulated/wall/bunker.dm
+++ b/code/_core/turf/simulated/wall/bunker.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/bunker
 	name = "bunker wall"
+	desc = "Ha, try getting through that"
+	desc_extended = "A thick steel wall made to withstand heavy punishment, maybe just try the door."
 	icon = 'icons/turf/wall/bunker.dmi'
 	icon_state = "wall"
 	corner_category = "metal"

--- a/code/_core/turf/simulated/wall/clockwork.dm
+++ b/code/_core/turf/simulated/wall/clockwork.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/clockwork
 	name = "clockwork wall"
+	desc = "Tick Tock motherfucker"
+	desc_extended = "A wall made of brass, a faint ticking can be heard inside."
 	icon = 'icons/turf/wall/clockwork.dmi'
 	icon_state = "wall"
 	corner_category = "clockwork"
@@ -11,13 +13,18 @@
 
 /turf/simulated/wall/clockwork/indestructable
 	name = "indestructable clockwork wall"
+	desc = "Tick Tock motherfucker"
+	desc_extended = "A wall made of brass, a faint ticking can be heard inside. This one is empowered by the energies of Ratvar and is therefore indestructible"
 	destruction_turf = null
 	health = null
 	color = "#C0C0C0"
 
 /turf/simulated/wall/clockwork/tough
 	name = "heated clockwork wall"
+	desc = "That's hot"
+	desc_extended = "A wall made of brass, a faint ticking can be heard inside. This one seems to be heated and is more durable."
 	color = "#FFC9C9"
+
 
 	destruction_turf = /turf/simulated/floor/plating
 

--- a/code/_core/turf/simulated/wall/cult.dm
+++ b/code/_core/turf/simulated/wall/cult.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/cult
 	name = "cult wall"
+	desc = "Spooky"
+	desc_extended = "A wall made of a stange runic metal, simply looking at it makes you nervous."
 	icon = 'icons/turf/wall/cult.dmi'
 	icon_state = "wall"
 	corner_category = "cult_wall"

--- a/code/_core/turf/simulated/wall/hierophant.dm
+++ b/code/_core/turf/simulated/wall/hierophant.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/hierophant
 	name = "hierophant wall"
+	desc = "Very purple"
+	desc_extended = "a wall made of an unknown metal, there are rippling patterns of purple light across it."
 	icon = 'icons/turf/wall/hierophant.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE

--- a/code/_core/turf/simulated/wall/ice.dm
+++ b/code/_core/turf/simulated/wall/ice.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/ice
 	name = "ice wall"
+	desc = "Ice, ice, baby"
+	desc_extended = "A wall made of ice"
 	icon = 'icons/turf/wall/ice.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE

--- a/code/_core/turf/simulated/wall/metal.dm
+++ b/code/_core/turf/simulated/wall/metal.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/metal
 	name = "steel wall"
+	desc = "Try getting through that"
+	desc_extended = "It's a wall made of solid steel, pretty tough."
 	icon = 'icons/turf/wall/metal_new.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE
@@ -37,6 +39,8 @@
 
 /turf/simulated/wall/metal/reinforced
 	name = "plasteel reinforced steel wall"
+	desc = "Try getting through that"
+	desc_extended = "It's a wall made of steel reinforced with plasteel, really tough."
 	icon_state = "wall_ref"
 	reinforced_material_id = /material/plasteel
 	reinforced_color = COLOR_PLASTEEL
@@ -44,6 +48,8 @@
 
 /turf/simulated/wall/metal/reinforced/hull
 	name = "adamantium-carbon reinforced plasteel wall"
+	desc = "Try getting through that"
+	desc_extended = "It's a wall made of plasteel reinforced with an adamantium-carbon alloy, extremely tough."
 	reinforced_material_id = /material/adamantium_carbon
 	color = "#48482B"
 	reinforced_color = COLOR_ADAMANITUM_CARBON

--- a/code/_core/turf/simulated/wall/river.dm
+++ b/code/_core/turf/simulated/wall/river.dm
@@ -1,5 +1,7 @@
 /turf/simulated/floor/river
 	name = "river"
+	desc = "It moves!"
+	desc_extended = "It's a river, where does it come from and where it goes is something only cotton eyed Joe knows.
 	icon = 'icons/turf/floor/water.dmi'
 	icon_state = "riverwater"
 	opacity = 0

--- a/code/_core/turf/simulated/wall/rock.dm
+++ b/code/_core/turf/simulated/wall/rock.dm
@@ -1,6 +1,9 @@
 /turf/simulated/wall/rock
 	name = "rock wall"
 
+	desc = "Rock hard"
+	desc_extended = "A natural wall made of rock, might have something behind it, might not, occasionally has minerals."
+
 	icon = 'icons/turf/wall/rock_preview.dmi'
 	icon_state = "rock"
 
@@ -28,6 +31,9 @@
 	real_icon = 'icons/turf/wall/rock_snow.dmi'
 	real_icon_state = "wall"
 
+	desc = "Rock hard"
+	desc_extended = "A natural wall made of rock, might have something behind it, might not, occasionally has minerals. This one has snow on it."
+
 	icon_state = "snow"
 
 	corner_icons = TRUE
@@ -36,6 +42,9 @@
 /turf/simulated/wall/rock/basalt
 	real_icon = 'icons/turf/wall/rock_basalt.dmi'
 	real_icon_state = "wall"
+
+	desc = "Rock hard"
+	desc_extended = "A natural wall made of basalt, occasionally has minerals."
 
 	icon_state = "basalt"
 
@@ -49,6 +58,9 @@
 	real_icon = 'icons/turf/wall/rock_brown.dmi'
 	real_icon_state = "wall"
 
+	desc = "Rock hard"
+	desc_extended = "A natural wall made of rock, might have something behind it, might not, occasionally has minerals. This one is brown."
+
 	icon_state = "brown"
 
 	corner_icons = TRUE
@@ -57,6 +69,9 @@
 /turf/simulated/wall/rock/moss
 	real_icon = 'icons/turf/wall/rock_moss.dmi'
 	real_icon_state = "wall"
+
+	desc = "Rock hard"
+	desc_extended = "A natural wall made of rock, might have something behind it, might not, occasionally has minerals. this one has moss on it."
 
 	icon_state = "moss"
 
@@ -67,6 +82,9 @@
 	real_icon = 'icons/turf/wall/rock_desert.dmi'
 	real_icon_state = "wall"
 
+	desc = "Rock hard"
+	desc_extended = "A natural wall made of rock, might have something behind it, might not, occasionally has minerals. This one is sandy."
+
 	icon_state = "desert"
 
 	corner_icons = TRUE
@@ -75,6 +93,9 @@
 /turf/simulated/wall/rock/ice
 	real_icon = 'icons/turf/wall/rock_ice.dmi'
 	real_icon_state = "ice"
+
+	desc = "Rock hard"
+	desc_extended = "A natural wall made of rock, might have something behind it, might not, occasionally has minerals. This one is icey."
 
 	icon_state = "ice"
 
@@ -85,6 +106,9 @@
 
 /turf/simulated/wall/rock/indestructable
 	name = "bedrock wall"
+
+	desc = "End of the line Bucko"
+	desc_extended = "An impassable barrier of stone, go around or turn around."
 
 	real_icon = 'icons/turf/wall/rock_bedrock.dmi'
 	real_icon_state = "wall"

--- a/code/_core/turf/simulated/wall/shuttle.dm
+++ b/code/_core/turf/simulated/wall/shuttle.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/shuttle
 	name = "shuttle wall"
+	desc = "Brace for landing"
+	desc_extended = "The wall of a shuttle."
 	icon = 'icons/turf/wall/shuttle_old.dmi'
 	icon_state = "wall"
 	corner_category = "shuttle"

--- a/code/_core/turf/simulated/wall/smooth.dm
+++ b/code/_core/turf/simulated/wall/smooth.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/plastic
 	name = "plastic wall"
+	desc = "Flexible"
+	desc_extended = " A wall made of plastic."
 	icon = 'icons/turf/wall/plastic.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE
@@ -10,8 +12,12 @@
 
 /turf/simulated/wall/plastic/office
 	name = "office wall"
+	desc = "Flexible"
+	desc_extended = " A wall made of plastic. This one seems boring."
 	color = "#DED4C8"
 
 /turf/simulated/wall/plastic/wizard
 	name = "wizard wall"
+	desc = "Flexible"
+	desc_extended = " A wall made of plastic. This one seems magical."
 	color = "#8034B2"

--- a/code/_core/turf/simulated/wall/traitor.dm
+++ b/code/_core/turf/simulated/wall/traitor.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/dark
 	name = "strong wall"
+	desc = "W E W L A D"
+	desc_extended = "A suspicious-looking wall."
 	icon = 'icons/turf/wall/shuttle_dark.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE
@@ -10,4 +12,6 @@
 
 /turf/simulated/wall/dark/shuttle
 	name = "syndicate shuttle wall"
+	desc = "He's got the disk!"
+	desc_extended = "The wall of a shuttle, this one belongs to the syndicate."
 	plane = PLANE_SHUTTLE

--- a/code/_core/turf/simulated/wall/wood.dm
+++ b/code/_core/turf/simulated/wall/wood.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/wood
 	name = "wall"
+	desc = "A wall made of wood"
+	desc_extended = "It's a wall, made of wood, something made it."
 	icon = 'icons/turf/wall/wood.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE
@@ -27,12 +29,20 @@
 
 /turf/simulated/wall/wood/brown
 	color = "#6F4533"
+	desc = "A wall made of wood"
+	desc_extended = "It's a wall, made of wood, something made it."
 
 /turf/simulated/wall/wood/rich
 	color = "#53331E"
+	desc = "A wall made of wood"
+	desc_extended = "It's a wall, made of wood, something made it. This one seems to be of a higher quality than most."
 
 /turf/simulated/wall/wood/boat
 	color = "#423022"
+	desc = "A wall made of wood"
+	desc_extended = "It's a wall, made of wood, something made it. This one is part of a boat."
 
 /turf/simulated/wall/wood/boat/starting
 	color = "#724C34"
+	desc = "A wall made of wood"
+	desc_extended = "It's a wall, made of wood, something made it. This one is part of a boat."

--- a/code/_core/turf/simulated/wall/xeno.dm
+++ b/code/_core/turf/simulated/wall/xeno.dm
@@ -1,5 +1,7 @@
 /turf/simulated/wall/xeno
 	name = "resin wall"
+	desc = "Ewww, sticky"
+	desc_extended = "A wall made of a strange resin, doesn't seem natural."
 	icon = 'icons/turf/wall/xeno.dmi'
 	icon_state = "wall"
 	corner_icons = TRUE


### PR DESCRIPTION
# What this PR does
See title, thought it might be more interesting to look at than "I bet not even the gods know what this is" on every single wall.

As of writing this the descs that I wrote do not display because they are overridden by code that I mention in my bug report.

# Why it should be added to the game
Adds some more flavor and can easily be changed later if need be.