### PR TITLE
Enable magazine enhancements

### DIFF
--- a/burgerstation.dme
+++ b/burgerstation.dme
@@ -1462,6 +1462,7 @@
 #include "code\_core\obj\item\storage\kits\_kits.dm"
 #include "code\_core\obj\item\tempering\_tempering.dm"
 #include "code\_core\obj\item\tempering\tempering_luck.dm"
+#include "code\_core\obj\item\tempering\tempering_magazine.dm"
 #include "code\_core\obj\item\tempering\tempering_quality.dm"
 #include "code\_core\obj\item\trigger\_device.dm"
 #include "code\_core\obj\item\trigger\keypad.dm"

--- a/code/_core/obj/item/magazine/_magazine.dm
+++ b/code/_core/obj/item/magazine/_magazine.dm
@@ -23,29 +23,22 @@
 	var/icon_states = 1
 	var/bluespaced = FALSE
 	var/regenerate = FALSE
-	var/regen_counter = 0
+	var/regen_speed = 30 //magazines can be allowed to regen faster or slower on an individual basis this way.
 
 	weight = 0.25
 
+//This callback activates when a refiller item is used on a magazine
+/obj/item/magazine/proc/regen()
+	if (length(stored_bullets) < bullet_count_max)
+		var/obj/item/bullet_cartridge/B = new ammo(src)
+		INITIALIZE(B)
+		GENERATE(B)
+		FINALIZE(B)
+		stored_bullets += B
+		update_sprite()
 
-/obj/item/magazine/PostInitialize()
-	start_thinking(src)
+	CALLBACK("regen_\ref[src]", regen_speed, src, /obj/item/magazine/proc/regen)
 	return ..()
-
-/obj/item/magazine/think()
-	if (regenerate)
-		regen_counter += 1
-		if (regen_counter > 30)
-			regen_counter = 0
-			if (length(stored_bullets) < bullet_count_max)
-				var/obj/item/bullet_cartridge/B = new ammo(src)
-				INITIALIZE(B)
-				FINALIZE(B)
-				stored_bullets += B
-				update_sprite()
-
-	return ..()
-
 
 /obj/item/magazine/update_icon()
 
@@ -86,6 +79,7 @@
 			for(var/i=1,i<=v,i++)
 				var/obj/item/bullet_cartridge/B = new k(src)
 				INITIALIZE(B)
+				GENERATE(B)
 				FINALIZE(B)
 				stored_bullets += B
 
@@ -95,7 +89,7 @@
 
 	if (object_data["regenerate"])
 		regenerate = TRUE
-
+		regen()
 
 /obj/item/magazine/Generate()
 
@@ -103,6 +97,7 @@
 		for(var/i=1, i <= bullet_count_max, i++)
 			var/obj/item/bullet_cartridge/B = new ammo(src)
 			INITIALIZE(B)
+			GENERATE(B)
 			FINALIZE(B)
 			stored_bullets += B
 
@@ -128,9 +123,9 @@
 /obj/item/magazine/get_examine_list(var/mob/examiner)
 	var results = div("notice","It contains [length(stored_bullets)] bullets.")
 	if (bluespaced)
-		results += div("notice", "It has been connected to a bluespace pocket to drastically increase its capacity")
+		results += div("notice", "It has been connected to a bluespace pocket to drastically increase its capacity. ")
 	if (regenerate)
-		results += div("notice", "It magically creates its own bullets every 3 seconds.")
+		results += div("notice", "It magically creates its own bullets every [src.regen_speed / 10] seconds. ")
 	return ..()  + results
 
 /obj/item/magazine/New()

--- a/code/_core/obj/item/tempering/tempering_magazine.dm
+++ b/code/_core/obj/item/tempering/tempering_magazine.dm
@@ -14,10 +14,10 @@
 	value = 50000
 
 /obj/item/tempering/magazine/bluespace/can_temper(var/mob/caller,var/obj/item/magazine/I)
-	if (is_magazine(I) == FALSE)
+	if (!is_magazine(I))
 		return FALSE
 
-	if(I.bluespaced == TRUE)
+	if(I.bluespaced)
 		caller.to_chat(span("warning","\The [I.name] is already bluespaced!"))
 		return FALSE
 
@@ -39,10 +39,10 @@
 	value = 50000
 
 /obj/item/tempering/magazine/refiller/can_temper(var/mob/caller,var/obj/item/magazine/I)
-	if (is_magazine(I) == FALSE)
+	if (!is_magazine(I))
 		return FALSE
 
-	if(I.regenerate == TRUE)
+	if(I.regenerate)
 		caller.to_chat(span("warning","\The [I.name] already has the regenerate enchantment applied!"))
 		return FALSE
 
@@ -50,4 +50,6 @@
 
 /obj/item/tempering/magazine/refiller/on_temper(var/mob/caller,var/obj/item/magazine/I)
 	I.regenerate = TRUE
+	I.regen()
 	return ..()
+

--- a/code/_core/obj/item/tempering/tempering_magazine.dm
+++ b/code/_core/obj/item/tempering/tempering_magazine.dm
@@ -1,0 +1,53 @@
+/obj/item/tempering/magazine
+	name = "magazine improvement"
+	desc = "You shouldn't be seeing this..."
+	desc_extended = "Report this to burger."
+
+/obj/item/tempering/magazine/bluespace
+	name = "Magazine bluespacer"
+	desc = "Have you tried just putting more bullets in it?"
+	desc_extended = "A tightly controlled bluespace pocket condenser. Fits to expand inside a magazine, and increases capacity 10x for that magazine"
+	icon_state = "quality_melee"
+
+	temper_whitelist = /obj/item/magazine
+
+	value = 50000
+
+/obj/item/tempering/magazine/bluespace/can_temper(var/mob/caller,var/obj/item/magazine/I)
+	if (is_magazine(I) == FALSE)
+		return FALSE
+
+	if(I.bluespaced == TRUE)
+		caller.to_chat(span("warning","\The [I.name] is already bluespaced!"))
+		return FALSE
+
+	return ..()
+
+/obj/item/tempering/magazine/bluespace/on_temper(var/mob/caller,var/obj/item/magazine/I)
+	I.bluespaced = TRUE
+	I.bullet_count_max *= 10
+	return ..()
+
+/obj/item/tempering/magazine/refiller
+	name = "Enchantment of Endless Bullets"
+	desc = "Not the fastest enhcantment ever, but it works"
+	desc_extended = "Eldritch forces will ensure your magazine refills over time, in exchange for... a fat stack of credits?"
+	icon_state = "quality_melee"
+
+	temper_whitelist = /obj/item/magazine
+
+	value = 50000
+
+/obj/item/tempering/magazine/refiller/can_temper(var/mob/caller,var/obj/item/magazine/I)
+	if (is_magazine(I) == FALSE)
+		return FALSE
+
+	if(I.regenerate == TRUE)
+		caller.to_chat(span("warning","\The [I.name] already has the regenerate enchantment applied!"))
+		return FALSE
+
+	return ..()
+
+/obj/item/tempering/magazine/refiller/on_temper(var/mob/caller,var/obj/item/magazine/I)
+	I.regenerate = TRUE
+	return ..()


### PR DESCRIPTION
# What this PR does
This code addition allows magazines for weapons to be enhanced in 2 separate ways, and creates items to apply those enhancements.
* A Bluespacer enhancement allows a magazine to hold 10x its normal capacity.
* A Refiller enchantment lets a magazine regenerate 1 bullet every 3 seconds on it's own.
Both items are set to a cost of 50,000 credits. These would make a great credit sink, since combined a player would be dropping 100k credits on a single magazine (and therefore a single gun) as a personal goal or a way to escape managing a dozen reloads per trip out of the station. 

# What this PR DOESN'T do
* Make these enhancement items available. 
* Handle the weapons that don't use a magazine (lasers, revolvers, most shotguns)
* Add icons for these items. Currently reusing the whetstone icon until these get approved, because sprites are hard.
* Understand any balance concerns that these would break. I would love to discuss these somewhere
** I don't see any public list of rules/math that explain out 'balance' in Burgerstation, or any 'goals' for players beyond the core gameplay loop of killing bosses and restocking at base.
** I had originally assumed that these would be purchased from cargo or a vendor in the rich-player vending machines, hence the cost. If these were instead made as a boss drop, they won't dramatically inflate the economy since the conversion to gold means a player will only get 2400 credits from selling one. This should certainly encourage using or trading them over selling them to the bank NPC.
** I made these changes shortly before the first iteration of BurgerStation shut down, when the general assumption was that magic was overpowered, guns were meh, and melee was bad. On the short time the new iteration has been up, the new assumption seems to be that guns are good, melee is good, and magic is bad. An understanding of the distinction between the 3 categories and if there's any specific/unique properties that should be done to each/any of them would help work this into the game. Are they only separated by damage types available? Costs for items? Should there be something like these items for the other categories of attacks?

# Why it should be added to the game
A: The core idea for this change is good for players and the station economy.
B: Players have a way to get out of one aspect of inventory management at a high (but viable) cost.
C: Players can have a goal to make their gun the best it can be, instead of just buying one from a vendor and running with it.
D: The goal is repeatable as players experiment and take a liking to different weapons, or occasionally die and lose their gun with the enhanced magazine.
E: I'm entirely open to discussions/adjustments of the idea and the numbers involved. Or making multiple steps of each if desired.