### PR TITLE
7 new plants growable in botany

### DIFF
--- a/code/_core/datum/plant/_plant_type.dm
+++ b/code/_core/datum/plant/_plant_type.dm
@@ -247,3 +247,71 @@
 		/reagent/toxin/angel_toxin = 0.5,
 		/reagent/drug/space = 0.25
 	)
+
+/plant_type/corn
+	name = "corn"
+	desc = "Corn is the smartest plant alive. It evolved Space Americans to grow it."
+	plant_icon_state = "corn"
+	harvest_icon_state = "corn"
+	seed_icon_state = "corn"
+	plant_icon_count = 1
+	reagents = list(
+		/reagent/nutrition/corn_flour = 1,
+	)
+
+	typical_volume = 8
+
+/plant_type/potato
+	name = "potato"
+	desc = "A staple food from many countries. Edible, fermentable, collectable?"
+	plant_icon_state = "potato"
+	harvest_icon_state = "potato"
+	seed_icon_state = "potato"
+	plant_icon_count = 1
+	reagents = list(
+		/reagent/nutrition/potato = 0.7,
+		/reagent/iron = 0.3
+	)
+
+	typical_volume = 10
+
+/plant_type/cactus
+	name = "cactus"
+	desc = "A succulent from dry, desert biomes."
+	plant_icon_state = "cactus"
+	harvest_icon = 'icons/obj/structure/botany.dmi'
+	harvest_icon_state = "cactus-harvest"
+	seed_icon_state = "cactus"
+	plant_icon_count = 1
+	reagents = list(
+		/reagent/nutrition/cactus = 1
+	)
+
+	typical_volume = 6
+
+/plant_type/chili
+	name = "chili pepper"
+	desc = "Why do you eat plants that make your face hurt?"
+	plant_icon_state = "chili"
+	harvest_icon_state = "chilipepper"
+	seed_icon_state = "chili"
+	plant_icon_count = 1
+	reagents = list(
+		/reagent/nutrition/capsaicin = 1
+	)
+
+	typical_volume = 2
+
+/plant_type/chili/ghost
+	name = "ghost pepper"
+	desc = "Why do you eat plants that make your soul hurt?"
+	plant_icon_state = "chili"
+	harvest_icon_state = "icepepper"
+	seed_icon_state = "chili_ghost"
+	plant_icon_count = 1
+	reagents = list(
+		/reagent/nutrition/capsaicin = 0.9,
+		/reagent/medicine/adrenaline = 0.1
+	)
+
+	typical_volume = 12

--- a/code/_core/datum/plant/_plant_type.dm
+++ b/code/_core/datum/plant/_plant_type.dm
@@ -256,7 +256,7 @@
 	seed_icon_state = "corn"
 	plant_icon_count = 1
 	reagents = list(
-		/reagent/nutrition/corn_flour = 1,
+		/reagent/nutrition/corn = 1,
 	)
 
 	typical_volume = 8

--- a/code/_core/datum/reagent/reagent_nutrition_grain.dm
+++ b/code/_core/datum/reagent/reagent_nutrition_grain.dm
@@ -54,9 +54,30 @@
 
 	particle_size = 0.3
 
+/reagent/nutrition/corn
+	name = "corn"
+	desc = "De-cobbed corn. Process this to get corn flour."
+	color = "#FCFC00"
+	alpha = 255
+
+	nutrition_amount = 4
+
+	flavor = "tough maize"
+
+	processed_reagent = /reagent/nutrition/corn_flour
+
+	liquid = -0.75
+
+	flavor_strength = 4
+
+	flags_flavor = FLAG_FLAVOR_GROSS | FLAG_FLAVOR_GRAIN
+
+	particle_size = 0.9
+
+
 /reagent/nutrition/corn_flour
 	name = "corn flour"
-	desc = "Also called corn starch. One of the biproducts of processing corn."
+	desc = "Also called corn starch. One of the by-products of processing corn."
 	color = "#E0AC33"
 
 	nutrition_amount = 5

--- a/code/_core/datum/reagent/reagent_nutrition_plants.dm
+++ b/code/_core/datum/reagent/reagent_nutrition_plants.dm
@@ -193,3 +193,61 @@
 
 	particle_size = 0.1
 
+/reagent/nutrition/potato
+	name = "potato"
+	desc = "Nutrition and flavor from potatoes."
+	color = "#FFFFEA"
+
+	nutrition_amount = 6
+	nutrition_quality_amount = 3
+
+	flavor = "ground apples"
+
+	liquid = 0
+
+	particle_size = 0.8
+
+
+/reagent/nutrition/cactus
+	name = "cactus"
+	desc = "Nutrition and flavor from cacti."
+	color = "#5AFF36"
+
+	nutrition_amount = 2
+	nutrition_quality_amount = 5
+	hydration_amount = 10
+
+	flavor = "crunchy water"
+
+	liquid = 0
+
+	particle_size = 0.1
+
+
+/reagent/nutrition/capsaicin
+	name = "capsaicin"
+	desc = "The pain juice."
+	color = "#EF3232"
+
+	nutrition_amount = 1
+	nutrition_quality_amount = 1
+	hydration_amount = -4
+
+	flavor = "hurting"
+
+	liquid = 0
+
+	particle_size = 0.2
+
+/reagent/nutrition/capsaicin/on_metabolize_stomach(var/mob/living/owner,var/reagent_container/container,var/starting_volume=0,var/multiplier=1)
+
+	. = ..()
+	owner.pain_regen_buffer += -starting_volume
+	owner.send_pain(starting_volume)
+
+
+/reagent/nutrition/capsaicin/on_metabolize_blood(var/mob/living/owner,var/reagent_container/container,var/starting_volume=0,var/multiplier=1)
+
+	. = ..()
+	owner.pain_regen_buffer += -starting_volume * 0.5
+	owner.send_pain(starting_volume * 0.5)

--- a/code/_core/obj/item/seed/seed_types.dm
+++ b/code/_core/obj/item/seed/seed_types.dm
@@ -109,3 +109,81 @@
 
 /obj/item/seed/cannabis/death
 	plant_type = /plant_type/cannabis/death
+
+/obj/item/seed/corn
+	plant_type = /plant_type/corn
+
+	growth_min = 0
+	growth_max = 100
+	growth_produce_max = 200
+
+	potency = 8
+	yield = 15
+	growth_speed = 5
+
+	delete_after_harvest = FALSE
+
+/obj/item/seed/sugarcane
+	plant_type = /plant_type/sugarcane
+
+	growth_min = 0
+	growth_max = 100
+	growth_produce_max = 200
+
+	potency = 5
+	yield = 4
+	growth_speed = 4.5
+
+	delete_after_harvest = TRUE
+
+/obj/item/seed/potato
+	plant_type = /plant_type/potato
+
+	growth_min = 0
+	growth_max = 100
+	growth_produce_max = 200
+
+	potency = 9
+	yield = 6
+	growth_speed = 5
+
+	delete_after_harvest = TRUE
+
+/obj/item/seed/cactus
+	plant_type = /plant_type/cactus
+
+	growth_min = 0
+	growth_max = 100
+	growth_produce_max = 200
+
+	potency = 10
+	yield = 3
+	growth_speed = 3
+
+	delete_after_harvest = TRUE
+
+/obj/item/seed/chili
+	plant_type = /plant_type/chili
+
+	growth_min = 0
+	growth_max = 100
+	growth_produce_max = 200
+
+	potency = 3
+	yield = 4
+	growth_speed = 4
+
+	delete_after_harvest = FALSE
+
+/obj/item/seed/chili/ghost
+	plant_type = /plant_type/chili/ghost
+
+	growth_min = 0
+	growth_max = 100
+	growth_produce_max = 200
+
+	potency = 10
+	yield = 2
+	growth_speed = 2
+
+	delete_after_harvest = TRUE

--- a/code/_core/obj/structure/interactive/local_machine/vendor/vendor_types.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/vendor_types.dm
@@ -351,7 +351,13 @@
 		/obj/item/seed/poppy,
 		/obj/item/seed/cannabis,
 		/obj/item/seed/cannabis/life,
-		/obj/item/seed/cannabis/death
+		/obj/item/seed/cannabis/death,
+		/obj/item/seed/corn,
+		/obj/item/seed/sugarcane,
+		/obj/item/seed/potato,
+		/obj/item/seed/cactus,
+		/obj/item/seed/chili,
+		/obj/item/seed/chili/ghost
 	)
 
 /obj/structure/interactive/vending/soda


### PR DESCRIPTION
# What this PR does
Adds 7 new plants and 1 new reagent
Adds corn (grows corn flour)
Adds sugarcane seeds (sugarcane was already coded in, it gives sugar that doesn't have the quality penalty)
Adds chili peppers as a source of capsaicin.
Adds ghosts peppers as a source of lots of capsaicin and a small amount of adrenaline. Go ahead, have a pepper eating contest.
Adds potatoes (food with some iron content, for healing bloodloss)
Adds cactus (solid food, primarily hydrates. Allows you to eat and drink in 1 click if added to a burger)
New reagent: capsaicin. It causes pain damage to the consumer.
This PR is independent of my other botany related PR.

# Why it should be added to the game
A: Makes some stuff already in the code accessible
B: Provides a couple new useful foods that could be snuck into burgers.
C: Provides a couple new fun foods.