### PR TITLE
swaggy ass reagent examine visibility bullshit and beaker precision

### DIFF
--- a/code/_core/obj/item/container/beaker/_beaker.dm
+++ b/code/_core/obj/item/container/beaker/_beaker.dm
@@ -62,6 +62,14 @@
 
 	INTERACT_CHECK
 	INTERACT_DELAY(1)
+	if(caller.attack_flags & CONTROL_MOD_DISARM)
+		var/choice = input("How much do you want to transfer at once?","Min: 0.5 Max: [reagents.volume_max]") as null|num
+		INTERACT_CHECK
+		if(choice)
+			transfer_amount = clamp(choice,0.5,reagents.volume_max)
+			caller.to_chat(span("notice","You will now transfer [transfer_amount] units at a time with \the [src]."))
+			return TRUE
+		else return TRUE
 
 	var/initial_amount = initial(transfer_amount)
 

--- a/code/_core/obj/item/container/beaker/cigarette.dm
+++ b/code/_core/obj/item/container/beaker/cigarette.dm
@@ -31,6 +31,8 @@
 
 	size = SIZE_1
 
+/obj/item/container/cigarette/get_examine_list(var/mob/examiner)
+	return ..() + div("notice",reagents.get_contents_english())
 
 /obj/item/container/cigarette/clicked_on_by_object(var/mob/caller,var/atom/object,location,control,params)
 	if(!lit)

--- a/code/_core/obj/item/container/medicine/spray.dm
+++ b/code/_core/obj/item/container/medicine/spray.dm
@@ -92,3 +92,6 @@
 
 
 	return ..()
+
+/obj/item/container/spray/get_examine_list(var/mob/examiner)
+	return ..() + div("notice",reagents.get_contents_english())

--- a/code/_core/obj/item/storage/bags/_bags.dm
+++ b/code/_core/obj/item/storage/bags/_bags.dm
@@ -163,6 +163,8 @@
 	var/color_label = "#FFFFFF"
 	var/color_canister = "#D35400"
 
+	appearance_flags = RESET_COLOR
+
 	drop_sound = 'sound/items/drop/pillbottle.ogg'
 
 	value = 20

--- a/code/_core/obj/item/weapon/ranged/reagent_sprayer/_reagent_sprayer.dm
+++ b/code/_core/obj/item/weapon/ranged/reagent_sprayer/_reagent_sprayer.dm
@@ -39,6 +39,8 @@
 		var/obj/projectile/P = k
 		reagents.transfer_reagents_to(P.reagents,reagent_per_shot, caller = caller)
 
+/obj/item/weapon/ranged/reagent_sprayer/get_examine_list(var/mob/examiner)
+	return ..() + div("notice",reagents.get_contents_english())
 
 /obj/item/weapon/ranged/reagent_sprayer/spray_bottle
 	name = "spray bottle"

--- a/code/_core/obj/structure/interactive/local_machine/vendor/vendor_types.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/vendor_types.dm
@@ -162,6 +162,8 @@
 		/obj/item/storage/bags/chemistry,
 		/obj/item/storage/pillbottle,
 		/obj/item/container/syringe,
+		/obj/item/container/spray,
+		/obj/item/weapon/ranged/reagent_sprayer/spray_bottle,
 		/obj/item/container/beaker/vial,
 		/obj/item/container/beaker/bottle/large,
 		/obj/item/container/beaker/bottle,


### PR DESCRIPTION
# What this PR does
-""""fixes"""" pill bottles to properly show the pill colors
-alt clicking beaker-type items allows you to choose precisely how much reagent you want to transfer (0.5 minimum)
-you can examine (applicable) sprays, spray bottles and cigarettes for their reagents 
-adds empty sprays and spray bottle to the chemistry vendor
# Why it should be added to the game
fixes are gnarly   (: 🥇🥇🥇🥇<-- for me👍👍🥇🥇👍👍👍🥇🔢  
sidenote when i was about to start the PR it automatically copy pasted the description of the first commit and it got me actin differently
anyway have this image
![mushroom](https://user-images.githubusercontent.com/9487319/125647051-109c5aef-e9a7-449a-8116-288fa463fadf.png)
