### PR TITLE
Adds aluminium to smelter (I FORGOT PLS SPEEDMERGE)

### DIFF
--- a/code/_core/datum/recipe/smelter.dm
+++ b/code/_core/datum/recipe/smelter.dm
@@ -79,3 +79,9 @@
 	desc = "alloy steel and phoron into plasteel sheets."
 	required_items = list("ingot_steel","ingot_phoron")
 	product = /obj/item/material/ingot/plasteel
+
+/recipe/smelter/aluminium
+	name = "smelt aluminium"
+	desc = "smelt aluminium into aluminium ingots."
+	required_items = list("ore_aluminium")
+	product = /obj/item/material/ingot/aluminium


### PR DESCRIPTION
# What this PR does
Adds aluminium smelting

# Why it should be added to the game
Makes aluminium smeltable and that's good because it's used in, like, half of the available recipes.