### PR TITLE
Makes magician's gems work, for real.

### DIFF
--- a/code/_core/obj/item/tempering/tempering_quality.dm
+++ b/code/_core/obj/item/tempering/tempering_quality.dm
@@ -73,10 +73,10 @@
 /obj/item/tempering/quality/magic
 	name = "magician's gem"
 	desc = "Stay on top of things."
-	desc_extended = "A fragile, yet magical gem that improves the quality of magicical tomes or staves by 5%, up to 125%. If the improvement results in a quality value less than 100%, it will set the quality to 100%."
+	desc_extended = "A fragile, yet magical gem that improves the quality of spellgems by 5%, up to 125%. If the improvement results in a quality value less than 100%, it will set the quality to 100%."
 	icon_state = "quality_magic"
 
-	temper_whitelist = /obj/item/weapon/ranged/magic
+	temper_whitelist = /obj/item/weapon/ranged/spellgem
 
 	value = 500
 


### PR DESCRIPTION
# What this PR does
Acts as a bandaid to the problem and makes magician's gems work on spellgems.

# Why it should be added to the game

until magic is finalized, at least let us have this...

![image](https://user-images.githubusercontent.com/46296243/126063040-c22e41d2-ce77-494e-9bff-1521a08ca9f4.png)
