### PR TITLE
moves the rest of the dark rating to Arcane on the Bunny Ears, keeps holy penalty

### DIFF
--- a/code/_core/obj/item/clothing/head/hats/cat.dm
+++ b/code/_core/obj/item/clothing/head/hats/cat.dm
@@ -40,8 +40,7 @@
 
 	defense_rating = list(
 		HOLY = -80,
-		DARK = 40,
-		ARCANE = 40,
+		ARCANE = 80,
 		BLADE = -60,
 		BLUNT = -60,
 		PIERCE = -60


### PR DESCRIPTION
# What this PR does
moves dark rating to Arcane completely

# Why it should be added to the game

Makes Bunny Ears give more Arcane for better min-maxing.