### PR TITLE
quick-shoot magic gems from belt

### DIFF
--- a/code/_core/obj/item/weapon/ranged/spellgem/_spellgem.dm
+++ b/code/_core/obj/item/weapon/ranged/spellgem/_spellgem.dm
@@ -15,6 +15,7 @@
 	automatic = TRUE
 
 	use_loyalty_tag = TRUE
+	has_quick_function = TRUE
 
 /obj/item/weapon/ranged/spellgem/get_owner()
 
@@ -108,3 +109,6 @@
 	angle += ((bullet_num-1) - (bullet_num_max-1)*0.5)*spread_per_shot
 
 	return list(cos(angle),sin(angle))
+
+/obj/item/weapon/ranged/spellgem/quick(var/mob/caller,var/atom/object,location,params)
+	return shoot(caller,object,location,params)


### PR DESCRIPTION
# What this PR does
before PR: putting gems on belt would only allow you to place them in your hands pressing 1234 and so on
with PR: shoots them on a button press (: very funny and cute and cool and funny and actually kinda fun

note: this does not apply to wands, it will simply holster them but not quick-shoot them, they are stronger after all

# Why it should be added to the game
it very co ol
![swaggy](https://user-images.githubusercontent.com/9487319/127709019-98d3b682-b9ee-4763-9d74-987d54d83931.JPG)
anyone spriter want to make pin sprites for gems........... jus sayin................ hmu......................