### PR TITLE
Increased maximum amount of coins in the stack

### DIFF
--- a/code/_core/obj/item/currency/_currency.dm
+++ b/code/_core/obj/item/currency/_currency.dm
@@ -115,7 +115,7 @@
 	icon_state = "1"
 	value = -1 //Value is based on current economy, see get_base_value()
 
-	item_count_max = 200
+	item_count_max = 4000
 
 	size = SIZE_4/200
 	weight = 50/200


### PR DESCRIPTION
# What this PR does
Increases the maximum amount of coins in the stack from 200 coins to 4k coins.

# Why it should be added to the game
Better storaging good.