### PR TITLE
fixes a typo in the ammo box description

### DIFF
--- a/code/_core/obj/item/storage/ammo.dm
+++ b/code/_core/obj/item/storage/ammo.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/ammo/
 	name = "ammo box"
-	desc = "Contains amoo"
+	desc = "Contains ammo."
 	icon = 'icons/obj/item/storage/ammo.dmi'
 	icon_state = "template"
 


### PR DESCRIPTION
# What this PR does
Fixes a typo in ammo boxes.

# Why it should be added to the game
I don't need to explain shit. Typos are bad.