### PR TITLE
Makes the syndisuit actually lightweight, and therefore agile.

### DIFF
--- a/code/_core/obj/item/clothing/overwear/hardsuit/syndicate.dm
+++ b/code/_core/obj/item/clothing/overwear/hardsuit/syndicate.dm
@@ -80,6 +80,7 @@
 	additional_clothing = list(/obj/item/clothing/head/helmet/hardsuit/syndie/elite)
 
 	size = SIZE_6
+	weight = 10 //Now the suit actually speeds you up.
 
 	value = 1200
 


### PR DESCRIPTION
# What this PR does
see title
also, since there's no TC value var

uhhhhhhhhhhhhhhhhhhhh

# Why it should be added to the game
>lightweight and agile
>one of the heaviest armors around