### PR TITLE
Golems now get a snowflake vendor that sells a mining hardsuit with the golem loyalty tag.

### DIFF
--- a/code/_core/obj/item/clothing/overwear/hardsuit/mining.dm
+++ b/code/_core/obj/item/clothing/overwear/hardsuit/mining.dm
@@ -26,3 +26,6 @@
 	value = 1000
 
 	loyalty_tag = "NanoTrasen"
+
+/obj/item/clothing/overwear/hardsuit/mining/golem
+	loyalty_tag = "golem"

--- a/code/_core/obj/structure/interactive/local_machine/vendor/mining.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/mining.dm
@@ -32,3 +32,35 @@
 		/obj/item/crafting/workbench,
 		/obj/item/clothing/overwear/hardsuit/mining
 	)
+
+/obj/structure/interactive/vending/mining/golem
+	stored_types = list(
+		/obj/item/clothing/underbottom/underwear/boxers,
+		/obj/item/clothing/undertop/underwear/shirt,
+		/obj/item/clothing/feet/socks/knee,
+		/obj/item/clothing/uniform/miner,
+		/obj/item/clothing/uniform/utility/supply,
+		/obj/item/storage/shoebox/miner,
+		/obj/item/storage/glovebox/brown_padded,
+		/obj/item/clothing/belt/storage/colored/brown,
+		/obj/item/clothing/overwear/armor/explorer_suit,
+		/obj/item/clothing/mask/gas/mining,
+		/obj/item/clothing/overwear/coat/vest/colored/brown,
+		/obj/item/clothing/back/storage/backpack/explorer,
+		/obj/item/storage/pouch/single/brown,
+		/obj/item/storage/pouch/double/brown,
+		/obj/item/storage/pouch/triple/brown,
+		/obj/item/weapon/melee/torch/lantern,
+		/obj/item/storage/bags/mining,
+		/obj/item/crafting/smelter,
+		/obj/item/weapon/melee/tool/pickaxe,
+		/obj/item/weapon/melee/tool/shovel,
+		/obj/item/weapon/melee/tool/screwdriver,
+		/obj/item/weapon/melee/tool/wrench,
+		/obj/item/supply_remote/drill,
+		/obj/item/flare,
+		/obj/item/weapon/ranged/energy/pump/kinetic_accelerator,
+		/obj/item/weapon/ranged/energy/fed/plasma_cutter,
+		/obj/item/crafting/workbench,
+		/obj/item/clothing/overwear/hardsuit/mining/golem // golem loyalty tag
+	)

--- a/maps/prefabs/antag/golem_shuttle.dmm
+++ b/maps/prefabs/antag/golem_shuttle.dmm
@@ -45,13 +45,13 @@
 /turf/simulated/floor/tile/shuttle/purple,
 /area/dmm_suite/clear_area)
 "m" = (
-/obj/structure/interactive/vending/mining,
+/obj/structure/interactive/vending/mining/golem,
 /turf/simulated/floor/tile/shuttle/purple,
 /area/dmm_suite/clear_area)
 "n" = (
 /obj/structure/interactive/lighting/fixture/tube/station{
-	icon_state = "preview";
-	dir = 1
+	dir = 1;
+	icon_state = "preview"
 	},
 /turf/simulated/floor/tile/shuttle,
 /area/dmm_suite/clear_area)
@@ -61,8 +61,8 @@
 /area/dmm_suite/clear_area)
 "p" = (
 /obj/structure/interactive/lighting/fixture/tube/station{
-	icon_state = "preview";
-	dir = 8
+	dir = 8;
+	icon_state = "preview"
 	},
 /obj/structure/smooth/table/rack/grey,
 /obj/item/weapon/melee/tool/pickaxe,
@@ -87,15 +87,15 @@
 /area/dmm_suite/clear_area)
 "u" = (
 /obj/structure/interactive/lighting/fixture/tube/station/strong{
-	icon_state = "preview";
-	dir = 1
+	dir = 1;
+	icon_state = "preview"
 	},
 /turf/simulated/floor/tile/shuttle/purple,
 /area/dmm_suite/clear_area)
 "v" = (
 /obj/structure/interactive/lighting/fixture/tube/station{
-	icon_state = "preview";
-	dir = 1
+	dir = 1;
+	icon_state = "preview"
 	},
 /turf/simulated/floor/tile/shuttle/purple,
 /area/dmm_suite/clear_area)
@@ -106,8 +106,8 @@
 "x" = (
 /obj/structure/smooth/table/wood,
 /obj/structure/interactive/lighting/fixture/tube/station{
-	icon_state = "preview";
-	dir = 1
+	dir = 1;
+	icon_state = "preview"
 	},
 /turf/simulated/floor/tile/shuttle/purple,
 /area/dmm_suite/clear_area)


### PR DESCRIPTION
# What this PR does
Adds a subtype of the mining hardsuit with a changed loyalty tag.
Adds a subtype of the mining vendor WITH that mining hardsuit subtype.
Replaces the mining vendors in the golem ship WITH the mining vendor subtype.

# Why it should be added to the game
Ideally, golems shouldn't be given unusable equipment.