### PR TITLE
Fix Whetstone and Added Several Melee Weapon to Contract Reward Pool

### DIFF
--- a/code/_core/obj/item/tempering/tempering_quality.dm
+++ b/code/_core/obj/item/tempering/tempering_quality.dm
@@ -43,7 +43,7 @@
 	desc_extended = "A special whetstone that improves the quality of a melee weapon by 5%, up to 125%. If the improvement results in a quality value less than 100%, it will set the quality to 100%.  Even works on non-sharp objects, somehow."
 	icon_state = "quality_melee"
 
-	temper_whitelist = /obj/item/weapon/melee
+	temper_whitelist = /obj/item/weapon/melee || /obj/item/weapon/unarmed
 
 	value = 500
 

--- a/code/_core/obj/item/weapon/melee/ling_blade.dm
+++ b/code/_core/obj/item/weapon/melee/ling_blade.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/item/weapons/melee/swords/arm_blade.dmi'
 	damage_type = /damagetype/melee/sword/armblade
 
-	value = -1
+	value = 5000
 	value_burgerbux = 1
 
 	drop_sound = 'sound/items/drop/axe.ogg'

--- a/code/_core/obj/structure/interactive/local_machine/vendor/contract.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/contract.dm
@@ -19,6 +19,12 @@
 		/obj/item/weapon/ranged/bullet/magazine/rifle/marksman/mod,
 		/obj/item/weapon/ranged/bullet/magazine/smg/fbi/mod,
 		/obj/item/weapon/ranged/bullet/pump/shotgun/combat/mod,
+		/obj/item/weapon/melee/energy/sword/katana,
+		/obj/item/weapon/melee/energy/stunbaton,
+		/obj/item/weapon/melee/sword/zweihander,
+		/obj/item/weapon/melee/sword/armblade,
+		/obj/item/weapon/unarmed/brass_knuckles,
+		/obj/item/weapon/unarmed/powerfist
 	)
 
 


### PR DESCRIPTION
# What this PR does
See Title
Whetstone can now temper brass knuckles and other UNARMED weapon
Add more melee weapon to contract reward pool
# Why it should be added to the game
Bugfix & Variety