### PR TITLE
adds bluespace rifts again

### DIFF
--- a/maps/jungle/z_01.dmm
+++ b/maps/jungle/z_01.dmm
@@ -16,8 +16,8 @@
 /area/fob/main)
 "ae" = (
 /obj/decal/hazard/black{
-	icon_state = "line";
-	dir = 4
+	dir = 4;
+	icon_state = "line"
 	},
 /turf/simulated/floor/plating,
 /area/fob/main)
@@ -26,8 +26,8 @@
 /area/transit/dropship/bravo/landing)
 "ag" = (
 /obj/decal/hazard/black{
-	icon_state = "line";
-	dir = 8
+	dir = 8;
+	icon_state = "line"
 	},
 /turf/simulated/floor/plating,
 /area/fob/main)
@@ -36,8 +36,8 @@
 /area)
 "ai" = (
 /obj/decal/hazard/black{
-	icon_state = "line";
-	dir = 1
+	dir = 1;
+	icon_state = "line"
 	},
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
@@ -53,15 +53,15 @@
 /area/fob/main)
 "am" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
 "an" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 10
+	dir = 10;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/tan/ish,
 /area/fob/main)
@@ -93,8 +93,8 @@
 /area)
 "av" = (
 /obj/decal/poster/nanotrasen{
-	icon_state = "";
-	dir = 4
+	dir = 4;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal,
 /area/fob/main)
@@ -135,22 +135,22 @@
 "aF" = (
 /obj/structure/interactive/disposals/machine/chute,
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tile/tan/ish,
 /area/fob/main)
 "aG" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/tan/ish,
 /area/fob/main)
 "aH" = (
 /obj/structure/interactive/disposals/pipe/x{
-	icon_state = "pipe-4way";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-4way"
 	},
 /turf/simulated/floor/tile/tan,
 /area/fob/main)
@@ -169,23 +169,23 @@
 /area)
 "aL" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/tan,
 /area/fob/main)
 "aM" = (
 /obj/structure/interactive/disposals/machine/chute,
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tile/tan/ish,
 /area/fob/main)
 "aN" = (
 /obj/decal/poster/nanotrasen{
-	icon_state = "";
-	dir = 1
+	dir = 1;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal,
 /area/fob/main)
@@ -208,8 +208,8 @@
 /area/fob/main)
 "aS" = (
 /obj/decal/poster/nanotrasen{
-	icon_state = "";
-	dir = 8
+	dir = 8;
+	icon_state = ""
 	},
 /turf/simulated/wall/metal,
 /area/fob/main)
@@ -272,29 +272,29 @@
 /area/fob/main)
 "bi" = (
 /obj/structure/interactive/chair/wood{
-	icon_state = "wooden_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "wooden_chair"
 	},
 /turf/simulated/floor/carpet,
 /area/fob/main)
 "bj" = (
 /obj/structure/interactive/chair/wood{
-	icon_state = "wooden_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
 /turf/simulated/floor/carpet,
 /area/fob/main)
 "bk" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 6
+	dir = 6;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/morphing/nanotrasen,
 /area/fob/main)
 "bl" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /obj/structure/interactive/door/airlock/lz_420,
 /turf/simulated/floor/tile/morphing/nanotrasen,
@@ -302,38 +302,38 @@
 "bm" = (
 /obj/marker/portal/nanotrasen,
 /obj/structure/interactive/disposals/pipe/x{
-	icon_state = "pipe-4way";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-4way"
 	},
 /turf/simulated/floor/tile/tan,
 /area/fob/main)
 "bn" = (
 /obj/marker/portal/nanotrasen,
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/tan,
 /area/fob/main)
 "bo" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /obj/structure/interactive/door/airlock/lz_420,
 /turf/simulated/floor/wood/brown,
 /area/fob/main)
 "bp" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 10
+	dir = 10;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/wood/brown,
 /area/fob/main)
 "bq" = (
 /mob/living/advanced/npc/unique/contractor{
-	icon_state = "directional";
-	dir = 8
+	dir = 8;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/carpet,
 /area/fob/main)
@@ -344,15 +344,15 @@
 "bs" = (
 /obj/structure/interactive/disposals/machine/chute,
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
 "bt" = (
 /obj/structure/interactive/disposals/pipe/junction/flipped{
-	icon_state = "pipe-j2";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tile/tan,
 /area/fob/main)
@@ -373,34 +373,34 @@
 "bx" = (
 /obj/structure/interactive/disposals/machine/chute,
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tile/morphing/nanotrasen,
 /area/fob/main)
 "by" = (
 /obj/structure/interactive/disposals/pipe/junction{
-	icon_state = "pipe-j1";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tile/tan,
 /area/fob/main)
 "bz" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 10
+	dir = 10;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
 "bA" = (
 /obj/structure/interactive/disposals/machine/chute,
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/wood/brown,
 /area/fob/main)
@@ -419,8 +419,8 @@
 /area/fob/main)
 "bE" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 5
+	dir = 5;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
@@ -439,16 +439,16 @@
 /area/fob/main)
 "bI" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /obj/structure/interactive/door/airlock/lz_420,
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
 "bJ" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 9
+	dir = 9;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
@@ -458,40 +458,40 @@
 /area/fob/main)
 "bM" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/plating,
 /area)
 "bN" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/plating,
 /area/fob/main)
 "bO" = (
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /obj/structure/interactive/disposals/machine/outlet/random{
-	icon_state = "outlet";
-	dir = 8
+	dir = 8;
+	icon_state = "outlet"
 	},
 /turf/unsimulated/generation/surface/cave_path_turf,
 /area)
 "bP" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /turf/unsimulated/generation/surface/cave_path_turf,
 /area)
 "bQ" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 10
+	dir = 10;
+	icon_state = "pipe"
 	},
 /turf/unsimulated/generation/surface/cave_path_turf,
 /area)
@@ -501,8 +501,8 @@
 /area)
 "bS" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 5
+	dir = 5;
+	icon_state = "pipe"
 	},
 /turf/unsimulated/generation/surface/cave_path_turf,
 /area)
@@ -518,8 +518,8 @@
 /area/fob/main)
 "bX" = (
 /obj/structure/interactive/disposals/pipe/x{
-	icon_state = "pipe-4way";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-4way"
 	},
 /turf/simulated/floor/tile/tan/ish,
 /area/fob/main)
@@ -534,20 +534,20 @@
 /area/fob/power)
 "ce" = (
 /turf/simulated/floor/stair{
-	icon_state = "stair_left";
-	dir = 1
+	dir = 1;
+	icon_state = "stair_left"
 	},
 /area/fob/power)
 "cf" = (
 /turf/simulated/floor/stair{
-	icon_state = "stair_middle";
-	dir = 1
+	dir = 1;
+	icon_state = "stair_middle"
 	},
 /area/fob/power)
 "cg" = (
 /turf/simulated/floor/stair{
-	icon_state = "stair_right";
-	dir = 1
+	dir = 1;
+	icon_state = "stair_right"
 	},
 /area/fob/power)
 "ch" = (
@@ -622,15 +622,15 @@
 /area/fob/main)
 "cx" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 9
+	dir = 9;
+	icon_state = "pipe"
 	},
 /turf/simulated/floor/plating,
 /area/fob/main)
 "cy" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /obj/structure/interactive/door/airlock/lz_420,
 /turf/simulated/floor/tile/tan,
@@ -640,8 +640,8 @@
 	pixel_x = -32
 	},
 /obj/structure/interactive/misc/sink{
-	icon_state = "sink";
-	dir = 8
+	dir = 8;
+	icon_state = "sink"
 	},
 /turf/simulated/floor/tile,
 /area/fob/main)
@@ -665,16 +665,16 @@
 "cE" = (
 /obj/structure/interactive/disposals/machine/chute,
 /obj/structure/interactive/disposals/pipe/ending{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /obj/structure/interactive/lighting/fixture/tube/station,
 /turf/simulated/floor/tile/grey/ish,
 /area/fob/main)
 "cF" = (
 /obj/structure/interactive/disposals/pipe{
-	icon_state = "pipe";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe"
 	},
 /obj/structure/interactive/lighting/fixture/tube/station{
 	dir = 1
@@ -785,6 +785,10 @@
 "eW" = (
 /obj/marker/prefab/medium,
 /turf/unsimulated/generation/surface/surface_turf,
+/area)
+"ga" = (
+/obj/marker/rift_location,
+/turf/unsimulated/generation/surface/cave_path_turf,
 /area)
 "hj" = (
 /obj/marker/prefab/boss,
@@ -938,6 +942,15 @@
 /obj/marker/prefab/boss,
 /turf/unsimulated/generation/surface/cave_turf,
 /area)
+"ER" = (
+/obj/marker/rift_location,
+/turf/unsimulated/generation/surface/surface_turf,
+/area)
+"JJ" = (
+/obj/structure/smooth/table/wood,
+/obj/marker/rift_location,
+/turf/simulated/floor/carpet,
+/area/fob/main)
 
 (1,1,1) = {"
 ab
@@ -1898,7 +1911,7 @@ ah
 ah
 au
 au
-au
+ga
 au
 aA
 au
@@ -20749,7 +20762,7 @@ ah
 ah
 au
 au
-au
+ga
 au
 au
 au
@@ -23196,7 +23209,7 @@ aC
 aC
 aC
 aC
-aC
+ER
 aC
 aC
 aC
@@ -29457,7 +29470,7 @@ au
 au
 au
 au
-au
+ga
 au
 au
 au
@@ -32611,7 +32624,7 @@ aC
 aC
 aC
 aC
-aC
+ER
 aC
 aC
 aC
@@ -39350,7 +39363,7 @@ aC
 aC
 aC
 aC
-aC
+ER
 aC
 aC
 aC
@@ -47860,7 +47873,7 @@ aC
 aC
 aC
 aC
-aC
+ER
 aC
 aC
 aC
@@ -48489,7 +48502,7 @@ ab
 ah
 ah
 ak
-au
+ga
 au
 au
 au
@@ -51598,7 +51611,7 @@ ah
 ah
 aC
 aC
-aC
+ER
 aC
 aC
 aC
@@ -62137,7 +62150,7 @@ at
 at
 ao
 aZ
-bf
+JJ
 be
 be
 aY

--- a/maps/jungle/z_02.dmm
+++ b/maps/jungle/z_02.dmm
@@ -196,6 +196,14 @@
 /obj/item/weapon/melee/tool/pickaxe,
 /turf/simulated/floor/brick/grey/dark/ish,
 /area/dungeon/z_02)
+"Q" = (
+/obj/marker/rift_location,
+/turf/simulated/floor/wood/dock,
+/area/dungeon/z_02)
+"X" = (
+/obj/marker/rift_location,
+/turf/simulated/floor/brick/grey/dark/ish,
+/area/dungeon/z_02)
 
 (1,1,1) = {"
 a
@@ -8407,7 +8415,7 @@ u
 d
 t
 f
-f
+X
 f
 f
 u
@@ -12617,7 +12625,7 @@ c
 p
 p
 p
-p
+Q
 p
 p
 p
@@ -32927,7 +32935,7 @@ p
 p
 p
 p
-p
+Q
 p
 p
 p
@@ -41587,7 +41595,7 @@ f
 f
 P
 P
-f
+X
 b
 b
 b
@@ -47838,7 +47846,7 @@ p
 p
 p
 p
-p
+Q
 p
 p
 p
@@ -60690,7 +60698,7 @@ p
 p
 p
 p
-p
+Q
 p
 p
 p
@@ -61122,7 +61130,7 @@ f
 f
 i
 f
-f
+X
 f
 d
 f

--- a/maps/jungle/z_03.dmm
+++ b/maps/jungle/z_03.dmm
@@ -13,14 +13,14 @@
 /area/dungeon/z_03)
 "e" = (
 /turf/simulated/floor/stair/ztravel/wood{
-	icon_state = "stair_middle";
-	dir = 4
+	dir = 4;
+	icon_state = "stair_middle"
 	},
 /area/dungeon/z_03)
 "f" = (
 /turf/simulated/floor/stair/ztravel/wood{
-	icon_state = "stair_middle";
-	dir = 8
+	dir = 8;
+	icon_state = "stair_middle"
 	},
 /area/dungeon/z_03)
 "g" = (
@@ -38,6 +38,10 @@
 "j" = (
 /obj/marker/prefab/large,
 /turf/unsimulated/generation/lava,
+/area/dungeon/z_03)
+"I" = (
+/obj/marker/rift_location,
+/turf/simulated/floor/brick/grey/dark/ish,
 /area/dungeon/z_03)
 
 (1,1,1) = {"
@@ -62250,7 +62254,7 @@ d
 d
 d
 d
-d
+I
 d
 d
 d


### PR DESCRIPTION
# What this PR does
Adds spawn markers for bluespace rifts, so if a player hits bluespace during transit they are teleported. Happens on all main Zlevels, there is only one on lavaland, four on the deep jungle, and ~8 or something on the top forest.

# Why it should be added to the game
You flash violently You flash violently You flash violently You flash violently You flash violently 