### PR TITLE
Adds the compact defib belt to the medical vendor

### DIFF
--- a/code/_core/obj/structure/interactive/local_machine/vendor/vendor_types.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/vendor_types.dm
@@ -196,7 +196,8 @@
 		/obj/item/clothing/pants/normal/medical,
 		/obj/item/clothing/uniform/utility/medical,
 		/obj/item/clothing/overwear/coat/labcoat/medical,
-		/obj/item/storage/glovebox/white
+		/obj/item/storage/glovebox/white,
+		/obj/item/defib/belt
 	)
 
 /obj/structure/interactive/vending/robotics


### PR DESCRIPTION
# What this PR does
Adds the compact defib belt to the medical vendor on the station.

# Why it should be added to the game
It's good for medics, may aswell add it. When alt click code is fixed it will have 4 tiles of space.