### PR TITLE
Fixing the PKM

### DIFF
--- a/code/_core/obj/item/magazine/lmg_762_r.dm
+++ b/code/_core/obj/item/magazine/lmg_762_r.dm
@@ -10,8 +10,8 @@
 		/obj/item/weapon/ranged/bullet/magazine/rifle/pkm = TRUE
 	)
 
-	ammo = /obj/item/bullet_cartridge/rifle_308/short
-	ammo_surplus = /obj/item/bullet_cartridge/rifle_308/short/surplus
+	ammo = /obj/item/bullet_cartridge/rifle_308/long
+	ammo_surplus = /obj/item/bullet_cartridge/rifle_308/long/surplus
 
 	bullet_length_min = 53
 	bullet_length_best = 54

--- a/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/pkm.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/pkm.dm
@@ -2,17 +2,22 @@
 	name = "\improper 7.62x54mmR PKM"
 	desc = "Killa's weapon of choice."
 	desc_extended = ""
-	icon = 'icons/obj/item/weapons/ranged/rifle/rev/762_lmg.dmi'
+	icon = 'icons/obj/item/weapons/ranged/rifle/PKM_old.dmi'
 	icon_state = "inventory"
 	value = 4000
 
 	shoot_delay = 1.75
 
+	automatic = TRUE
+
+	damage_mod = 1
+
+	firemodes = list("automatic","semi-automatic")
+
 	shoot_sounds = list('sound/weapons/russia/abakan.ogg')
 
 	can_wield = TRUE
 
-	automatic = TRUE
 
 	size = SIZE_5
 	weight = 20


### PR DESCRIPTION
Fixed the PKM not being able to fire by adding firemodes and correcting the bullet type in the magazine, and also reverted it back to the old sprite until the new sprites are fixed.

# What this PR does
Fixes the functionality of the PKM, and reverts it back to it's old sprite until the new one is finished.

# Why it should be added to the game
It's fixing a gun that's already in game that doesn't work in it's current state.