### PR TITLE
Mag refiller upgrade description tweak

### DIFF
--- a/code/_core/obj/item/tempering/tempering_magazine.dm
+++ b/code/_core/obj/item/tempering/tempering_magazine.dm
@@ -36,7 +36,7 @@
 /obj/item/tempering/magazine/refiller
 	name = "magazine refill upgrade system"
 	desc = "Subscribe to magazine+ to get the best of your bullets."
-	desc_extended = "A special digital rights management labeler that tells magazine restockers to fill the magazine with premium ammo. Single use."
+	desc_extended = "A special digital rights management labeler that tells magazine restockers to fill the magazine with standard quality ammo. Single use."
 	icon_state = "mag_enchant"
 
 	temper_whitelist = /obj/item/magazine


### PR DESCRIPTION
# What this PR does
Makes the mag refiller upgrade say it gives standard quality ammo instead of premium ammo, since apparently that's exactly what it does, according to a respectable smart dude on the discord.

# Why it should be added to the game
So people don't feel scammed.

Alternatively, I could try to figure out how to make it actually give premium ammo since that upgrade is really expensive, and really only a convenience so you don't have to order your mags from cargo anymore in the case of non NT guns, or use a vender for NT guns.