### PR TITLE
Fix warning recipes

### DIFF
--- a/code/_core/datum/reagent_recipe/drugs.dm
+++ b/code/_core/datum/reagent_recipe/drugs.dm
@@ -1,5 +1,6 @@
 /reagent_recipe/drugs/
 	category = "Chemistry"
+	results = list()
 
 /reagent_recipe/drugs/space_drugs
 

--- a/code/_core/datum/reagent_recipe/explosives.dm
+++ b/code/_core/datum/reagent_recipe/explosives.dm
@@ -1,5 +1,6 @@
 /reagent_recipe/explosion/
 	category = "Chemistry"
+	results = list()
 
 /reagent_recipe/explosion/water_potassium
 	name = "Water-Potassium Explosion"

--- a/code/_core/datum/reagent_recipe/magic.dm
+++ b/code/_core/datum/reagent_recipe/magic.dm
@@ -1,5 +1,6 @@
 /reagent_recipe/magic/
 	category = "Chemistry"
+	results = list()
 
 /reagent_recipe/magic/health_potion
 

--- a/code/_core/datum/reagent_recipe/medicine.dm
+++ b/code/_core/datum/reagent_recipe/medicine.dm
@@ -1,5 +1,6 @@
 /reagent_recipe/medicine/
 	category = "Chemistry"
+	results = list()
 
 /reagent_recipe/medicine/dexalin
 

--- a/code/_core/datum/reagent_recipe/misc.dm
+++ b/code/_core/datum/reagent_recipe/misc.dm
@@ -1,5 +1,6 @@
 /reagent_recipe/chemistry/
 	category = "Chemistry"
+	results = list()
 
 /reagent_recipe/chemistry/sodium_chloride
 	name = "Sodium Chloride"


### PR DESCRIPTION
# What this PR does
fix theese warnings:
 - Warning: /reagent_recipe/drugs had no reagent result(s)!
 - Warning: /reagent_recipe/explosion had no reagent result(s)!
 - Warning: /reagent_recipe/food had no reagent result(s)!
 - Warning: /reagent_recipe/magic had no reagent result(s)!
 - Warning: /reagent_recipe/medicine had no reagent result(s)!
 - Warning: /reagent_recipe/chemistry had no reagent result(s)!