### PR TITLE
Changes bow DPH, HPS and DPS calculations

### DIFF
--- a/code/_core/obj/item/weapon/ranged/bow/_bow.dm
+++ b/code/_core/obj/item/weapon/ranged/bow/_bow.dm
@@ -21,6 +21,7 @@
 
 	override_icon_state = TRUE
 
+	ranged_damage_type = /damagetype/ranged/bow/
 
 	heat_max = 0.03
 
@@ -175,6 +176,8 @@
 
 	value = 3000
 
+	ranged_damage_type = /damagetype/ranged/bow/hardlight
+
 	stage_per_decisecond = 10
 	stage_max = 50
 
@@ -205,3 +208,19 @@
 	stage_max = 125
 
 	tier = 4
+
+/obj/item/weapon/ranged/bow/get_damage_per_hit(armor_to_use)
+	var/damagetype/D = all_damage_types[ranged_damage_type]
+	var/DPH = D.get_damage_per_hit(armor_to_use) * max(1, src.item_count_max / 2) * ((stage_max / 100) + 0.25) / 2 //average shoot stack and average damage modifier used in calculations
+	log_debug("[src.name] have [DPH] damage per hit.")
+	return DPH 
+
+/obj/item/weapon/ranged/bow/get_hits_per_second() 
+	var/HPS = (stage_max / stage_per_decisecond / 10) //maximum stage time in seconds
+	HPS += 0.5 //minimum stage time 
+	HPS = HPS / 2 //average stage time for shoot
+	HPS += 1 //player lag for recharging to next shoot (empirical 1 second for fast clickers)
+	HPS = 1 / HPS //real hits per second
+	log_debug("[src.name] have [HPS] hits per second.")
+	return HPS //as idea give player delay ()
+	


### PR DESCRIPTION
# What this PR does
Bows damage per hit, hits per second and as result damage per second calculations are near real life.
TESTED by firing from all types of bows in 5 minutes test. It's works.

# Why it should be added to the game
NEEDED for balance subsystem.
**P.S.** Yes, at this monent bows are with **wrong** tiers. Need to change tiers or change damages. In first case all bows are tier 0 (by damage).