### PR TITLE
Fixes  mining drills being able to be rotated

### DIFF
--- a/code/_core/obj/structure/interactive/mining_drill.dm
+++ b/code/_core/obj/structure/interactive/mining_drill.dm
@@ -6,6 +6,7 @@
 
 	var/drill_depth = 0
 	var/drill_counter = 0
+	var/can_rotate = FALSE
 
 	var/obj/structure/interactive/ground_ore_deposit/found_deposit
 

--- a/code/_core/obj/structure/interactive/mining_drill.dm
+++ b/code/_core/obj/structure/interactive/mining_drill.dm
@@ -6,7 +6,7 @@
 
 	var/drill_depth = 0
 	var/drill_counter = 0
-	var/can_rotate = FALSE
+	can_rotate = FALSE
 
 	var/obj/structure/interactive/ground_ore_deposit/found_deposit
 


### PR DESCRIPTION
# What this PR does
Adds var/can_rotate = FALSE to mining drills, stops them from being able to be rotated... AKA you can turn them on and off again.

# Why it should be added to the game
bugfix- on Trello,