### PR TITLE
fixes players eating soda cans instead of drinking them

### DIFF
--- a/code/_core/obj/item/container/beaker/_beaker.dm
+++ b/code/_core/obj/item/container/beaker/_beaker.dm
@@ -30,7 +30,7 @@
 	return try_transfer_reagents(caller,caller,location,null,params)
 
 /obj/item/container/simple/beaker/get_consume_verb()
-	return "drink"
+	return "drink" //this
 
 /obj/item/container/simple/beaker/get_consume_sound()
 	return 'sound/items/consumables/drink.ogg'

--- a/code/_core/obj/item/container/can/_can.dm
+++ b/code/_core/obj/item/container/can/_can.dm
@@ -147,3 +147,8 @@
 	reagents.add_reagent(/reagent/nutrition/soda/space_up,reagents.volume_max)
 	open = FALSE
 	return ..()
+
+/obj/item/container/simple/can/get_consume_verb()
+	return "drink"
+/obj/item/container/simple/can/get_consume_sound()
+	return 'sound/items/consumables/drink.ogg'


### PR DESCRIPTION
# What this PR does
![image](https://user-images.githubusercontent.com/61367602/156633704-95892511-227f-4c92-b7b1-ada714bdc7af.png)
![image](https://user-images.githubusercontent.com/61367602/156633721-dbb10fc4-890d-477e-9133-759923cb4765.png)
I dont care if it was funny. 
adds get_consume_verb and get_consume_sound "Drink" to cans.

# Why it should be added to the game
bugfix, not on Trello