### PR TITLE
fixes RPGs breaking when shot

### DIFF
--- a/code/_core/obj/item/weapon/ranged/bullet/revolver/rocket.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/revolver/rocket.dm
@@ -1,4 +1,4 @@
-/obj/item/weapon/ranged/bullet/rocket
+/obj/item/weapon/ranged/bullet/revolver/rocket
 	name = "70mm NT Anti Armor Weapon System"
 	desc = "I'm a Rocket Man."
 	desc_extended = "NT's answer to the Syndicate Mechs and Borgs: NT AAWS. Single-shot portable anti-tank weapon, though if you're brave enough you can try to use it more than once."


### PR DESCRIPTION
# What this PR does
RPGs were their own weird type of weapon, you couldn't shoot them! now you can- again. They are now a subtype of revolver, one slot, very good.


https://user-images.githubusercontent.com/61367602/156718306-75e5c046-87d2-4f7e-b7c8-08a0abe124ff.mp4



# Why it should be added to the game
bugfix, rpg gang rise up