### PR TITLE
Throwing dragged

### DIFF
--- a/code/_core/atom/moveable/throwing.dm
+++ b/code/_core/atom/moveable/throwing.dm
@@ -12,6 +12,7 @@
 	if(istype(src.loc,/obj/projectile/thrown/))
 		return FALSE
 	var/damage_type_to_use = damage_type_thrown ? damage_type_thrown : damage_type
+	if(damage_type_to_use == /damagetype/error) damage_type_to_use = /damagetype/melee/club/stunbaton/on //Basically something broken OR mobs
 	var/obj/projectile/thrown/P = new(get_turf(src),thrower,src,vel_x,vel_y,target_x,target_y,get_turf(desired_target),damage_type_to_use,desired_target,"#FFFFFF",thrower,desired_iff = desired_iff)
 	P.appearance = src.appearance
 	P.pixel_x = src.pixel_x

--- a/code/_core/obj/hud/inventory/_inventory.dm
+++ b/code/_core/obj/hud/inventory/_inventory.dm
@@ -71,6 +71,9 @@
 
 	var/obj/hud/button/close_inventory/assoc_button
 
+	var/grab_level = 1 //Passive grab
+	var/grab_time //Cooldown on upgrading grab
+
 /obj/hud/inventory/Destroy()
 
 	if(grabbed_object)
@@ -137,9 +140,14 @@
 	if(parent_inventory)
 		color = "#ff0000"
 	else if(grabbed_object)
-		color = "#ffff00"
-		var/image/I = new/image(initial(icon),"grab")
-		add_overlay(I)
+		if(grab_level == 1) //Passive grab
+			color = "#ffff00"
+			var/image/I = new/image(initial(icon),"grab")
+			add_overlay(I)
+		else if(grab_level == 2) //Agressive grab
+			color = COLOR_RIVER_LIGHT
+			var/image/I = new/image(initial(icon),"grab")
+			add_overlay(I)
 	else
 		color = initial(color)
 

--- a/code/_core/obj/hud/inventory/grabbing.dm
+++ b/code/_core/obj/hud/inventory/grabbing.dm
@@ -26,6 +26,7 @@
 	caller.visible_message(span("warning","\The [caller.name] grabs \the [object.name]."),span("notice","You grab \the [object.name]."))
 	animate(grabbed_object,pixel_x = initial(grabbed_object.pixel_x), pixel_y = initial(grabbed_object.pixel_y), time = SECONDS_TO_DECISECONDS(1))
 	grabbed_object.grabbing_hand = src
+	grab_time = world.time //To prevent instant agressive grab
 
 	overlays.Cut()
 	update_overlays()
@@ -53,6 +54,7 @@
 		L.resist_counter = 0
 	grabbed_object.grabbing_hand = null
 	grabbed_object = null
+	grab_level = 1
 	overlays.Cut()
 	update_overlays()
 	return TRUE


### PR DESCRIPTION
# What this PR does
Allow you to throw dragged items and mobs.
Currently has only visual bug that causes you to "hit" target like in melee, but as I know, fix is on the way.
As other thing, if throwed has damagetype/error, overrides it as stunbaton's damagetype

# Why it should be added to the game
Old-new feature, Trello