### PR TITLE
Throwing dragged

### DIFF
--- a/code/_core/atom/moveable/throwing.dm
+++ b/code/_core/atom/moveable/throwing.dm
@@ -12,6 +12,7 @@
 	if(istype(src.loc,/obj/projectile/thrown/))
 		return FALSE
 	var/damage_type_to_use = damage_type_thrown ? damage_type_thrown : damage_type
+	if(damage_type_to_use == /damagetype/error) damage_type_to_use = /damagetype/melee/club/stunbaton //Basically something broken OR mobs
 	var/obj/projectile/thrown/P = new(get_turf(src),thrower,src,vel_x,vel_y,target_x,target_y,get_turf(desired_target),damage_type_to_use,desired_target,"#FFFFFF",thrower,desired_iff = desired_iff)
 	P.appearance = src.appearance
 	P.pixel_x = src.pixel_x

--- a/code/_core/obj/hud/inventory/_inventory.dm
+++ b/code/_core/obj/hud/inventory/_inventory.dm
@@ -71,6 +71,9 @@
 
 	var/obj/hud/button/close_inventory/assoc_button
 
+	var/grab_level = 1 //Passive grab
+	var/grab_time //Cooldown on upgrading grab
+
 /obj/hud/inventory/Destroy()
 
 	if(grabbed_object)
@@ -137,9 +140,14 @@
 	if(parent_inventory)
 		color = "#ff0000"
 	else if(grabbed_object)
-		color = "#ffff00"
-		var/image/I = new/image(initial(icon),"grab")
-		add_overlay(I)
+		if(grab_level == 1) //Passive grab
+			color = "#ffff00"
+			var/image/I = new/image(initial(icon),"grab")
+			add_overlay(I)
+		else if(grab_level == 2) //Agressive grab
+			color = COLOR_RIVER_LIGHT
+			var/image/I = new/image(initial(icon),"grab")
+			add_overlay(I)
 	else
 		color = initial(color)
 

--- a/code/_core/obj/hud/inventory/grabbing.dm
+++ b/code/_core/obj/hud/inventory/grabbing.dm
@@ -26,6 +26,7 @@
 	caller.visible_message(span("warning","\The [caller.name] grabs \the [object.name]."),span("notice","You grab \the [object.name]."))
 	animate(grabbed_object,pixel_x = initial(grabbed_object.pixel_x), pixel_y = initial(grabbed_object.pixel_y), time = SECONDS_TO_DECISECONDS(1))
 	grabbed_object.grabbing_hand = src
+	grab_time = world.time //To prevent instant agressive grab
 
 	overlays.Cut()
 	update_overlays()
@@ -53,6 +54,7 @@
 		L.resist_counter = 0
 	grabbed_object.grabbing_hand = null
 	grabbed_object = null
+	grab_level = 1
 	overlays.Cut()
 	update_overlays()
 	return TRUE

--- a/code/_core/obj/hud/inventory/interaction.dm
+++ b/code/_core/obj/hud/inventory/interaction.dm
@@ -43,29 +43,46 @@
 		if(!isturf(caller.loc))
 			return TRUE
 		var/mob/living/L = caller
-		caller.face_atom(object)
-		var/atom/movable/object_to_throw = top_object
+		caller.face_atom(object) //Changing dir
+		var/atom/movable/object_to_throw
+		if(grabbed_object) object_to_throw = grabbed_object //We want to throw something that we pull
+		else object_to_throw = top_object //Else we throw something in our hand
+
 		if(istype(object_to_throw))
-			var/obj/item/I = object_to_throw
-			if(I.additional_clothing_parent || I.no_drop)
-				caller.to_chat(span("warning","You can't throw this!"))
-				return TRUE
-			var/vel_x = object.x - caller.x
+			if(ismob(object_to_throw) && grab_level < 2) //To throw mob you need agressive grab
+				caller.to_chat(span("warning","You need a better grip to do that!"))
+				return TRUE //Isn't agressive grab on mob?
+
+			var/vel_x = object.x - caller.x //Caller pos is the same as object anyway
 			var/vel_y = object.y - caller.y
 			var/highest = max(abs(vel_x),abs(vel_y))
 
-			if(!highest)
-				I.drop_item(get_turf(caller)) //Drop if we can't throw.
+			if(highest == 0) //Our position is the same as target
+				release_object(caller) //Better not to divide by zero
 				return TRUE
 
-			vel_x *= 1/highest
-			vel_y *= 1/highest
+			if(is_item(object_to_throw)) //Item needs aditional procedures
+				var/obj/item/I = object_to_throw
+				if(I.additional_clothing_parent || I.no_drop) //Can't throw additional clothing
+					caller.to_chat(span("warning","You can't throw this!"))
+					return TRUE
+				if(!highest) //We want to throw it in us?.. No velocity
+					I.drop_item(get_turf(caller)) //Drop if we can't throw.
+					return TRUE
+				I.drop_item(get_turf(caller),silent=TRUE)
 
+			vel_x *= 1/highest
+			vel_y *= 1/highest //Should it be in two lines instead of four?
 			vel_x *= BULLET_SPEED_LARGE_PROJECTILE
 			vel_y *= BULLET_SPEED_LARGE_PROJECTILE
 
-			I.drop_item(get_turf(caller),silent=TRUE)
-			I.throw_self(caller,get_turf(object),text2num(params[PARAM_ICON_X]),text2num(params[PARAM_ICON_Y]),vel_x,vel_y,steps_allowed = VIEW_RANGE,lifetime = 30,desired_iff = L.iff_tag)
+			if(grabbed_object == object_to_throw)
+				grabbed_object.Move(get_turf(caller)) //Anti-offset
+				release_object(caller)
+
+			//Throwing it
+			object_to_throw.throw_self((grabbed_object ? grabbed_object : caller),object,text2num(params[PARAM_ICON_X]),text2num(params[PARAM_ICON_Y]),vel_x,vel_y,steps_allowed = VIEW_RANGE,lifetime = 30,desired_iff = L.iff_tag)
+
 		else if(top_object)
 			caller.to_chat(span("warning","You can't throw \the [top_object.name]!"))
 
@@ -94,8 +111,21 @@
 			drop_item_from_inventory(get_turf(src))
 		return TRUE
 
-	if(grabbed_object && grabbed_object == object)
-		release_object(caller)
+	if(grabbed_object && grabbed_object == object && is_living(grabbed_object)) //We click on the hand that grabbed something
+		if(world.time <= grab_time+DECISECONDS_TO_TICKS(20)) //Prevents insta agressive-grab
+			caller.to_chat(span("warning","Too soon to tighting your grip on [object]! Need to wait another [TICKS_TO_SECONDS(grab_time+DECISECONDS_TO_TICKS(20) - world.time)] seconds!"))
+			return TRUE
+		caller.to_chat(span("warning","You tighten your grip on [object]!"))
+		grab_level = 2 //Agressive grab
+		grab_time = world.time //We grabbed now. Used in agressive grab
+
+		var/mob/living/A = owner //How can something not alive grab anything?..
+		A.add_status_effect(SLOW,30,30) //I don't know any better way..
+		var/mob/living/V = grabbed_object //Checked above
+		V.add_status_effect(REST,30,30)
+		V.add_status_effect(SLOW,30,30)
+
+		update_overlays() //Changing appearnce
 		return TRUE
 
 	if(grabbed_object && isturf(grabbed_object.loc)) //Handle moving grabbed objects

--- a/code/_core/obj/hud/inventory/interaction.dm
+++ b/code/_core/obj/hud/inventory/interaction.dm
@@ -57,10 +57,6 @@
 			var/vel_y = object.y - caller.y
 			var/highest = max(abs(vel_x),abs(vel_y))
 
-			if(highest == 0) //Our position is the same as target
-				release_object(caller) //Better not to divide by zero
-				return TRUE
-
 			if(is_item(object_to_throw)) //Item needs aditional procedures
 				var/obj/item/I = object_to_throw
 				if(I.additional_clothing_parent || I.no_drop) //Can't throw additional clothing
@@ -70,6 +66,10 @@
 					I.drop_item(get_turf(caller)) //Drop if we can't throw.
 					return TRUE
 				I.drop_item(get_turf(caller),silent=TRUE)
+
+			if(highest == 0) //Our position is the same as target
+				release_object(caller) //Better not to divide by zero
+				return TRUE
 
 			vel_x *= 1/highest
 			vel_y *= 1/highest //Should it be in two lines instead of four?
@@ -113,16 +113,15 @@
 
 	if(grabbed_object && grabbed_object == object && is_living(grabbed_object)) //We click on the hand that grabbed something
 		if(world.time <= grab_time+DECISECONDS_TO_TICKS(20)) //Prevents insta agressive-grab
-			caller.to_chat(span("warning","Too soon to tighting your grip on [object]! Need to wait another [TICKS_TO_SECONDS(grab_time+DECISECONDS_TO_TICKS(20) - world.time)] seconds!"))
 			return TRUE
 		caller.to_chat(span("warning","You tighten your grip on [object]!"))
 		grab_level = 2 //Agressive grab
 		grab_time = world.time //We grabbed now. Used in agressive grab
 
 		var/mob/living/A = owner //How can something not alive grab anything?..
-		A.add_status_effect(SLOW,30,30) //I don't know any better way..
+		A.add_status_effect(SLOW,30,30,stealthy=1) //I don't know any better way..
 		var/mob/living/V = grabbed_object //Checked above
-		V.add_status_effect(REST,30,30)
+		V.add_status_effect(REST,30,30,stealthy=1)
 		V.add_status_effect(SLOW,30,30)
 
 		update_overlays() //Changing appearnce


### PR DESCRIPTION
# What this PR does
Allow you to throw dragged items and mobs(only with agressive grab).
Currently has only visual bug that causes you to "hit" target like in melee, but as I know, fix is on the way.
As another thing, if something throwed has "/damagetype/error", overrides it as stunbaton's /damagetype/

# Why it should be added to the game

Old-new feature, Trello