### PR TITLE
You can wield the tungsten SMG now.

### DIFF
--- a/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/tungsten.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/tungsten.dm
@@ -31,6 +31,8 @@
 	size = SIZE_3
 	weight = 12
 
+	can_wield = TRUE
+
 	ai_heat_sensitivity = 1.5
 
 	attachment_whitelist = list(


### PR DESCRIPTION
# What this PR does
Title. Bugfix. Shooting the tungsten SMG one-handed will cause you to cry in pain and drop it. It's supposed to be wieldable.

# Why it should be added to the game
bugfix.