### PR TITLE
3 NEW HOUSEPERFABS

### DIFF
--- a/code/_core/area/mission/prefabs/house.dm
+++ b/code/_core/area/mission/prefabs/house.dm
@@ -195,3 +195,85 @@
 
 /area/mission/prefab/house/house_08/closet
 	icon_state = "blue"
+
+
+
+
+//davidthtthird house 01
+/area/mission/prefab/house/house_D01
+	name = "house D01"
+	icon_state = "yellow"
+	requires_power = TRUE
+	link_to_parent_apc = TRUE
+	interior = TRUE
+
+/area/mission/prefab/house/house_D01/bathroom
+	icon_state = "blue"
+
+/area/mission/prefab/house/house_D01/kitchen
+	icon_state = "green"
+
+/area/mission/prefab/house/house_D01/main_hallway
+	icon_state = "purple"
+
+/area/mission/prefab/house/house_D01/bedroom01
+	icon_state = "cyan"
+
+/area/mission/prefab/house/house_D01/bedroom02
+	icon_state = "pink"
+
+
+
+	//davidthtthird house 02 homless person barracks
+/area/mission/prefab/house/house_D02
+	name = "house D02"
+	icon_state = "yellow"
+	requires_power = TRUE
+	link_to_parent_apc = TRUE
+	interior = TRUE
+
+/area/mission/prefab/house/house_D02/bathroom
+	icon_state = "blue"
+
+/area/mission/prefab/house/house_D02/kitchen
+	icon_state = "green"
+
+/area/mission/prefab/house/house_D02/hallway
+	icon_state = "purple"
+
+/area/mission/prefab/house/house_D02/officer_bedroom
+	icon_state = "cyan"
+
+/area/mission/prefab/house/house_D02/bunks
+	icon_state = "pink"
+
+
+
+		//davidthtthird house 03 "boxxed in"
+/area/mission/prefab/house/house_D03
+	name = "house D03"
+	icon_state = "yellow"
+	requires_power = TRUE
+	link_to_parent_apc = TRUE
+	interior = TRUE
+
+/area/mission/prefab/house/house_D03/bathroom
+	icon_state = "blue"
+
+/area/mission/prefab/house/house_D03/sec
+	icon_state = "green"
+
+/area/mission/prefab/house/house_D03/engi
+	icon_state = "purple"
+
+/area/mission/prefab/house/house_D03/science
+	icon_state = "cyan"
+
+/area/mission/prefab/house/house_D03/hallway
+	icon_state = "pink"
+
+/area/mission/prefab/house/house_D03/command
+	icon_state = "red"
+
+/area/mission/prefab/house/house_D03/chapple
+	icon_state = "brown"

--- a/maps/prefabs/house/D01.dmm
+++ b/maps/prefabs/house/D01.dmm
@@ -1,0 +1,772 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aD" = (
+/turf/simulated/floor/tile/coldroom,
+/area/mission/prefab/house/house_D01/bathroom)
+"cr" = (
+/obj/structure/table/wood,
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"cF" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01)
+"cK" = (
+/obj/structure/interactive/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 4
+	},
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"cP" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01)
+"dG" = (
+/obj/structure/interactive/misc/toilet{
+	icon_state = "toilet";
+	dir = 8
+	},
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 8
+	},
+/obj/marker/map_node,
+/turf/simulated/floor/tile/coldroom,
+/area/mission/prefab/house/house_D01/bathroom)
+"dK" = (
+/obj/structure/carpet/brown,
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"es" = (
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"ey" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01)
+"eE" = (
+/obj/structure/table/reinforced/steel,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/kitchen)
+"gI" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"je" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/valuable,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"jr" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"kH" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"kJ" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01/bedroom01)
+"lt" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"lx" = (
+/obj/structure/interactive/door/airlock/station,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/main_hallway)
+"lB" = (
+/obj/structure/interactive/light_switch{
+	icon_state = "setup";
+	dir = 4
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"mo" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"nO" = (
+/obj/structure/carpet/brown,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"oi" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"oU" = (
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/kitchen)
+"pi" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 8
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"pp" = (
+/turf/dmm_suite/clear_turf,
+/area/dmm_suite/clear_area)
+"pK" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"pX" = (
+/obj/structure/interactive/power/smes{
+	dir = 8
+	},
+/obj/structure/interactive/wire/red,
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"qC" = (
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"ra" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/tile/grey/ish)
+"rb" = (
+/obj/structure/carpet/brown,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"rq" = (
+/obj/structure/interactive/chair/comfy{
+	icon_state = "comfychair";
+	dir = 1
+	},
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"rv" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"tv" = (
+/obj/structure/interactive/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"tR" = (
+/obj/structure/interactive/wire/red,
+/obj/marker/map_node,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"tS" = (
+/obj/structure/table/reinforced/steel,
+/obj/structure/interactive/storage/ammo_pile,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D01/kitchen)
+"uA" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/bathroom)
+"uV" = (
+/obj/structure/interactive/light_switch{
+	icon_state = "setup";
+	dir = 4
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"uX" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/misc,
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"vg" = (
+/obj/structure/interactive/chair/stool/bar,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"vt" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"vG" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01)
+"xt" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 1
+	},
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/main_hallway)
+"xM" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/tile/coldroom,
+/area/mission/prefab/house/house_D01/bathroom)
+"zv" = (
+/obj/marker/map_node,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/main_hallway)
+"zx" = (
+/obj/structure/interactive/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01)
+"zC" = (
+/obj/structure/table/reinforced/steel,
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 4
+	},
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D01/kitchen)
+"Aa" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"Ah" = (
+/obj/structure/interactive/door/airlock/wood,
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"AE" = (
+/obj/structure/interactive/power/apc,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01)
+"AI" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"AZ" = (
+/obj/structure/interactive/door/airlock/station,
+/turf/simulated/floor/tile/coldroom,
+/area/mission/prefab/house/house_D01/bathroom)
+"BG" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01)
+"Ce" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"CK" = (
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D01/kitchen)
+"DW" = (
+/obj/structure/table/reinforced/steel,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/kitchen)
+"EB" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"ET" = (
+/obj/structure/table/cooking/grill,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D01/kitchen)
+"FL" = (
+/obj/structure/interactive/crate/trash,
+/obj/structure/interactive/lighting/fixture/bulb,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D01/kitchen)
+"Gl" = (
+/obj/structure/interactive/misc/tv,
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Hg" = (
+/mob/living/advanced/npc/survivor,
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Hp" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 8
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Ht" = (
+/obj/structure/interactive/storage/trash_pile,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"HW" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"Ie" = (
+/obj/structure/interactive/misc/sink{
+	icon_state = "sink";
+	dir = 8
+	},
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 1
+	},
+/turf/simulated/floor/tile/coldroom,
+/area/mission/prefab/house/house_D01/bathroom)
+"Ih" = (
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"IM" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Ja" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"Jz" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/main_hallway)
+"KA" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"KQ" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/dangerous,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"Lm" = (
+/obj/structure/interactive/chair/stool,
+/mob/living/advanced/npc/survivor,
+/obj/structure/interactive/wire/red,
+/obj/structure/interactive/wire/red,
+/obj/marker/map_node,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"Lq" = (
+/obj/structure/interactive/bed/sheet,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"LA" = (
+/obj/marker/map_node,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D01/kitchen)
+"LJ" = (
+/obj/structure/interactive/crate/closet/freezer,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D01/kitchen)
+"LK" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"My" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"MG" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"Na" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"Oq" = (
+/obj/structure/interactive/solar_panel,
+/obj/structure/interactive/wire/yellow,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"OA" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"OQ" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/main_hallway)
+"PS" = (
+/obj/structure/carpet/brown,
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom01)
+"Qg" = (
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Rd" = (
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/kitchen)
+"Rn" = (
+/obj/structure/interactive/bed/sheet,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"Rp" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D01/bathroom)
+"RD" = (
+/obj/structure/interactive/door/airlock/station/maintenance,
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"RT" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Si" = (
+/obj/structure/table/cooking/grill,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/kitchen)
+"Ux" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01)
+"Vg" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01/bedroom02)
+"Vp" = (
+/obj/structure/interactive/bookcase,
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"WD" = (
+/obj/structure/interactive/chair/comfy{
+	icon_state = "comfychair";
+	dir = 1
+	},
+/obj/structure/carpet/blue,
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Xg" = (
+/obj/structure/interactive/crate/closet/freezer,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D01/kitchen)
+"XO" = (
+/obj/structure/interactive/wire/yellow,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01)
+"Yr" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D01/kitchen)
+"YB" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/bedroom02)
+"YO" = (
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+"Zv" = (
+/obj/structure/table/wood,
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D01/main_hallway)
+
+(1,1,1) = {"
+pp
+pp
+pp
+pp
+pp
+oi
+oi
+oi
+Ih
+Ih
+Aa
+Aa
+Aa
+Aa
+Aa
+pp
+"}
+(2,1,1) = {"
+pp
+oi
+oi
+oi
+oi
+oi
+Na
+oi
+Ih
+Ih
+Aa
+je
+jr
+Rn
+Aa
+pp
+"}
+(3,1,1) = {"
+pp
+oi
+eE
+LJ
+Xg
+zC
+vg
+lB
+Yr
+Yr
+vt
+YB
+dK
+rb
+Vg
+Ih
+"}
+(4,1,1) = {"
+Ih
+Yr
+ET
+oU
+CK
+DW
+vg
+Rd
+Ce
+cr
+Aa
+KA
+rb
+rb
+Vg
+Ih
+"}
+(5,1,1) = {"
+Ih
+Yr
+Si
+CK
+oU
+tS
+vg
+HW
+HW
+HW
+Aa
+Aa
+Ja
+LK
+Aa
+pp
+"}
+(6,1,1) = {"
+pp
+oi
+FL
+oU
+LA
+oU
+qC
+HW
+qC
+HW
+MG
+HW
+Ah
+oi
+oi
+pp
+"}
+(7,1,1) = {"
+pp
+oi
+kH
+HW
+HW
+HW
+HW
+Rp
+AZ
+Rp
+My
+My
+AI
+lt
+My
+pp
+"}
+(8,1,1) = {"
+cF
+cF
+cK
+tv
+HW
+cF
+RD
+uA
+aD
+Ie
+My
+gI
+nO
+nO
+kJ
+Ih
+"}
+(9,1,1) = {"
+Oq
+cF
+Ux
+ey
+BG
+cF
+pK
+Rp
+dG
+xM
+mo
+OA
+PS
+nO
+kJ
+Ih
+"}
+(10,1,1) = {"
+Oq
+cF
+ey
+Ux
+BG
+AE
+pK
+Ht
+Rp
+Rp
+My
+KQ
+pi
+Lq
+My
+pp
+"}
+(11,1,1) = {"
+XO
+vG
+zx
+zx
+cP
+vG
+Lm
+pK
+pK
+tR
+My
+My
+My
+My
+My
+pp
+"}
+(12,1,1) = {"
+pX
+vG
+es
+rv
+rv
+EB
+EB
+EB
+uV
+RD
+EB
+RT
+Jz
+EB
+Ih
+Ih
+"}
+(13,1,1) = {"
+EB
+EB
+Vp
+YO
+YO
+rv
+rv
+rv
+rv
+rv
+rv
+Qg
+Qg
+lx
+Ih
+Ih
+"}
+(14,1,1) = {"
+pp
+EB
+Gl
+YO
+WD
+rv
+rv
+rv
+rv
+Hg
+rv
+zv
+xt
+EB
+Ih
+Ih
+"}
+(15,1,1) = {"
+pp
+EB
+Zv
+uX
+rq
+rv
+rv
+Hp
+rv
+rv
+rv
+OQ
+ra
+EB
+pp
+pp
+"}
+(16,1,1) = {"
+pp
+EB
+IM
+IM
+IM
+IM
+EB
+EB
+EB
+EB
+IM
+IM
+EB
+EB
+pp
+pp
+"}

--- a/maps/prefabs/house/D02.dmm
+++ b/maps/prefabs/house/D02.dmm
@@ -1,0 +1,775 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aE" = (
+/obj/structure/interactive/bed/sheet,
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"aP" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"cF" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"df" = (
+/obj/structure/interactive/door/airlock/station/command,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"dg" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"dE" = (
+/obj/structure/table/reinforced/steel,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"ei" = (
+/obj/structure/interactive/door/airlock/station/glass,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"ez" = (
+/obj/structure/table/rack/grey/light,
+/obj/item/magazine/m13_762,
+/obj/item/magazine/m13_762,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"eJ" = (
+/obj/structure/interactive/misc/toilet,
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/tile,
+/area/mission/prefab/house/house_D02/bathroom)
+"eV" = (
+/obj/structure/interactive/barricade{
+	icon_state = "metal";
+	dir = 4
+	},
+/obj/structure/interactive/barricade{
+	icon_state = "metal"
+	},
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"fc" = (
+/obj/structure/interactive/wire/yellow,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"gi" = (
+/obj/structure/interactive/light_switch{
+	icon_state = "setup";
+	dir = 8
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"gq" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"gr" = (
+/obj/structure/interactive/power/smes{
+	dir = 8
+	},
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"gG" = (
+/obj/structure/interactive/crate/closet,
+/obj/structure/carpet/blue,
+/obj/marker/spawning/random/valuable,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"hk" = (
+/mob/living/advanced/npc/survivor,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"hr" = (
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"iO" = (
+/obj/structure/interactive/chair/stool,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"jl" = (
+/obj/structure/table/cooking/grill,
+/obj/structure/interactive/lighting/fixture/tube,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"jx" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	dir = 1
+	},
+/turf/simulated/floor/tile,
+/area/mission/prefab/house/house_D02/bathroom)
+"jz" = (
+/obj/marker/spawning/random/maintenance,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"kl" = (
+/obj/structure/table/rack/grey/light,
+/obj/structure/interactive/storage/ammo_pile,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"ma" = (
+/obj/structure/table/reinforced/steel,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"mc" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"mz" = (
+/obj/structure/interactive/door/airlock/wood,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"mV" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/kitchen)
+"nh" = (
+/obj/structure/interactive/bed/sheet,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"nJ" = (
+/obj/structure/interactive/wire/red,
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"nY" = (
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"oB" = (
+/obj/structure/table/wood,
+/obj/structure/carpet/blue,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"oG" = (
+/obj/structure/interactive/door/airlock/station/janitor,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"oJ" = (
+/obj/structure/table/cooking/grill,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"oK" = (
+/obj/structure/interactive/barricade{
+	icon_state = "metal";
+	dir = 8
+	},
+/obj/structure/interactive/barricade{
+	icon_state = "metal"
+	},
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"oZ" = (
+/obj/structure/interactive/misc/urinal,
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02/bathroom)
+"ps" = (
+/turf/dmm_suite/clear_turf,
+/area/dmm_suite/clear_area)
+"pw" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"qG" = (
+/obj/structure/carpet/blue,
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"rn" = (
+/obj/structure/table/reinforced/steel,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"uY" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02/bunks)
+"vn" = (
+/obj/structure/interactive/barricade{
+	icon_state = "metal";
+	dir = 4
+	},
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"wc" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02/bathroom)
+"wH" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02)
+"wS" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"wZ" = (
+/obj/structure/interactive/crate/closet/freezer,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"xk" = (
+/obj/structure/interactive/crate/closet/freezer,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"za" = (
+/obj/structure/table/rack/grey/light,
+/obj/item/weapon/ranged/bullet/pump/shotgun/lever,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"zF" = (
+/obj/structure/carpet/blue,
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"zN" = (
+/obj/structure/carpet/blue,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"AY" = (
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"BW" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02/hallway)
+"CW" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"De" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D02/kitchen)
+"DE" = (
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02)
+"Fh" = (
+/turf/simulated/floor/tile,
+/area/mission/prefab/house/house_D02/bathroom)
+"Fj" = (
+/obj/structure/interactive/lighting/fixture/bulb,
+/obj/structure/interactive/barricade{
+	icon_state = "metal";
+	dir = 8
+	},
+/turf/dmm_suite/no_wall,
+/area/mission/prefab/house/house_D02/kitchen)
+"Fo" = (
+/obj/structure/table/reinforced/steel,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"Fp" = (
+/obj/structure/interactive/door/airlock/station,
+/turf/simulated/floor/tile,
+/area/mission/prefab/house/house_D02/bathroom)
+"Fu" = (
+/obj/structure/interactive/misc/sink{
+	icon_state = "sink";
+	dir = 4
+	},
+/turf/simulated/floor/tile,
+/area/mission/prefab/house/house_D02/bathroom)
+"FD" = (
+/obj/marker/map_node,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"FG" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"GE" = (
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"GT" = (
+/obj/structure/interactive/chair/office,
+/obj/structure/carpet/blue,
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"HT" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"Ic" = (
+/obj/structure/table/cooking/grill,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"Is" = (
+/obj/marker/spawning/random/trash,
+/obj/structure/table/rack/grey/light,
+/obj/structure/interactive/wire/red,
+/obj/marker/spawning/random/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"Jw" = (
+/obj/structure/interactive/chair/stool,
+/mob/living/advanced/npc/survivor,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"JR" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"Kn" = (
+/obj/structure/interactive/barricade{
+	icon_state = "metal";
+	dir = 8
+	},
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"KB" = (
+/obj/marker/map_node,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"Lr" = (
+/obj/structure/interactive/chair/stool,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"Lz" = (
+/obj/structure/interactive/lighting/fixture/tube{
+	dir = 1
+	},
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"ME" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"Nq" = (
+/obj/structure/interactive/bed/sheet,
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 8
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"NL" = (
+/obj/structure/interactive/chair/stool,
+/mob/living/advanced/npc/survivor,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"NU" = (
+/obj/structure/table/steel,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"OU" = (
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02/bathroom)
+"OW" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02)
+"PH" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02/bathroom)
+"Qh" = (
+/obj/structure/interactive/solar_panel,
+/obj/structure/interactive/wire/yellow,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02)
+"Qj" = (
+/obj/structure/interactive/light_switch{
+	icon_state = "setup";
+	dir = 8
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"Qu" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"QH" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"QV" = (
+/obj/structure/interactive/lighting/fixture/bulb,
+/obj/structure/interactive/barricade{
+	icon_state = "metal";
+	dir = 4
+	},
+/turf/dmm_suite/no_wall,
+/area/mission/prefab/house/house_D02/kitchen)
+"Rb" = (
+/obj/structure/carpet/blue,
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"Rr" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D02/kitchen)
+"Sh" = (
+/obj/structure/table/rack/grey/light,
+/obj/item/weapon/ranged/bullet/magazine/rifle/m13,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"SE" = (
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"SW" = (
+/obj/structure/table/reinforced/steel,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"TM" = (
+/obj/structure/interactive/intercom,
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"TN" = (
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D02/kitchen)
+"Wk" = (
+/obj/structure/short_wall/wood,
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"Ws" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/dangerous,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/hallway)
+"WK" = (
+/obj/structure/carpet/blue,
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"Xa" = (
+/obj/structure/table/steel,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+"Xh" = (
+/obj/structure/interactive/power/apc,
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02)
+"Xs" = (
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"XS" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D02/kitchen)
+"Yj" = (
+/obj/structure/interactive/light_switch{
+	dir = 4;
+	icon_state = "setup"
+	},
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D02/officer_bedroom)
+"Yk" = (
+/obj/structure/interactive/bed/sheet,
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D02/bunks)
+"YE" = (
+/obj/structure/interactive/door/airlock/station/glass,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D02/kitchen)
+
+(1,1,1) = {"
+Qh
+fc
+Qh
+OU
+PH
+PH
+SE
+mc
+Yj
+TM
+SE
+gq
+uY
+uY
+gq
+gq
+"}
+(2,1,1) = {"
+Qh
+fc
+gr
+OU
+eJ
+Fh
+SE
+aE
+GT
+oB
+SE
+Yk
+nh
+nh
+nh
+gq
+"}
+(3,1,1) = {"
+DE
+oG
+wH
+OU
+OU
+Fp
+SE
+zN
+zN
+oB
+SE
+cF
+Qu
+Qu
+pw
+gq
+"}
+(4,1,1) = {"
+Xh
+JR
+Is
+oZ
+Fh
+Fh
+SE
+qG
+zF
+zN
+df
+Qu
+Xs
+Qu
+pw
+gq
+"}
+(5,1,1) = {"
+OW
+JR
+kl
+oZ
+Fh
+jx
+SE
+Rb
+zN
+WK
+SE
+hr
+Qu
+Qu
+pw
+gq
+"}
+(6,1,1) = {"
+DE
+nJ
+jz
+wc
+Fu
+Fh
+SE
+gG
+zN
+Rb
+SE
+nh
+Qu
+Nq
+nh
+gq
+"}
+(7,1,1) = {"
+DE
+oG
+DE
+OU
+OU
+Fp
+SE
+SE
+df
+SE
+SE
+gq
+mz
+Qj
+gq
+gq
+"}
+(8,1,1) = {"
+De
+GE
+TN
+dE
+QH
+GE
+TN
+GE
+TN
+mV
+wS
+dg
+dg
+dg
+Ws
+HT
+"}
+(9,1,1) = {"
+Rr
+QH
+GE
+rn
+FD
+TN
+GE
+TN
+FD
+mV
+ME
+dg
+nY
+dg
+CW
+HT
+"}
+(10,1,1) = {"
+De
+Fo
+TN
+SW
+TN
+Jw
+NU
+Lr
+FG
+De
+HT
+gi
+BW
+BW
+HT
+HT
+"}
+(11,1,1) = {"
+De
+oJ
+hk
+ma
+GE
+iO
+Xa
+iO
+GE
+XS
+Wk
+Wk
+Wk
+Wk
+ps
+ps
+"}
+(12,1,1) = {"
+De
+jl
+TN
+dE
+TN
+Lr
+NU
+Lr
+Lz
+De
+Fj
+Kn
+oK
+Wk
+ps
+ps
+"}
+(13,1,1) = {"
+De
+Ic
+GE
+ma
+GE
+NL
+Xa
+iO
+GE
+YE
+AY
+AY
+AY
+AY
+AY
+AY
+"}
+(14,1,1) = {"
+De
+wZ
+TN
+Fo
+TN
+GE
+TN
+GE
+KB
+YE
+AY
+AY
+AY
+AY
+AY
+AY
+"}
+(15,1,1) = {"
+De
+xk
+FD
+ei
+FD
+za
+Sh
+ez
+aP
+De
+QV
+vn
+eV
+Wk
+ps
+ps
+"}
+(16,1,1) = {"
+De
+De
+De
+De
+XS
+XS
+XS
+XS
+De
+De
+Wk
+Wk
+Wk
+Wk
+ps
+ps
+"}

--- a/maps/prefabs/house/D03.dmm
+++ b/maps/prefabs/house/D03.dmm
@@ -1,0 +1,732 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aF" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D03/command)
+"aQ" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"br" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/bathroom)
+"bO" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03)
+"cy" = (
+/obj/structure/interactive/light_switch{
+	dir = 4;
+	icon_state = "setup"
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"dP" = (
+/obj/structure/table/rack/grey,
+/obj/item/weapon/melee/tool/wrench,
+/obj/item/weapon/melee/tool/crowbar,
+/obj/item/weapon/melee/tool/wirecutters,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"dX" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"eC" = (
+/obj/structure/interactive/door/airlock/station,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/sec)
+"fn" = (
+/obj/structure/interactive/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 4
+	},
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D03/command)
+"fx" = (
+/obj/structure/table/reinforced/steel,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D03/command)
+"gl" = (
+/obj/structure/interactive/bed/sheet,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"hk" = (
+/obj/structure/interactive/door/airlock/station,
+/turf/simulated/floor/tile,
+/area/mission/prefab/house/house_D03/bathroom)
+"jc" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"lM" = (
+/obj/structure/table/cooking/grill,
+/obj/marker/spawning/random/kitchen,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"lU" = (
+/obj/structure/interactive/misc/toilet,
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/tile,
+/area/mission/prefab/house/house_D03/bathroom)
+"lW" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D03/command)
+"me" = (
+/obj/structure/interactive/door/airlock/station/glass,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"mF" = (
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"ng" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03)
+"op" = (
+/obj/structure/interactive/power/smes{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03)
+"oY" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03)
+"pW" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"qE" = (
+/obj/structure/table/rack/grey,
+/obj/marker/spawning/random/trash,
+/obj/marker/spawning/random/trash,
+/obj/marker/spawning/random/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/hallway)
+"qQ" = (
+/mob/living/advanced/npc/survivor,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/sec)
+"rq" = (
+/turf/simulated/floor/tile/chapel/decor,
+/area/mission/prefab/house/house_D03/chapple)
+"sc" = (
+/obj/structure/interactive/light_switch{
+	icon_state = "setup";
+	dir = 1
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"si" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/sec)
+"su" = (
+/obj/structure/interactive/door/airlock/station/maintenance,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/hallway)
+"sH" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"tv" = (
+/obj/marker/map_node,
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 1
+	},
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"tO" = (
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 1
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"uJ" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/tile/chapel/decor{
+	dir = 8
+	},
+/area/mission/prefab/house/house_D03/chapple)
+"vv" = (
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"vz" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D03/command)
+"vG" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/chapple)
+"vK" = (
+/obj/structure/interactive/door/airlock/station,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/sec)
+"wg" = (
+/obj/structure/table/wood,
+/obj/structure/interactive/storage/ammo_pile,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"wr" = (
+/obj/structure/table/rack/grey,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/sec)
+"xy" = (
+/obj/structure/interactive/light_switch{
+	icon_state = "setup";
+	dir = 8
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/bathroom)
+"Ak" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"An" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 8
+	},
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"AG" = (
+/obj/structure/interactive/potted_plant/office,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"AN" = (
+/obj/structure/interactive/crate/closet/freezer,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"AP" = (
+/obj/structure/interactive/bed/sheet,
+/mob/living/advanced/npc/survivor{
+	icon_state = "directional";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"BJ" = (
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"CQ" = (
+/obj/structure/table/rack/grey,
+/obj/marker/spawning/random/valuable,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/sec)
+"CW" = (
+/obj/structure/interactive/door/airlock/station,
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"Dm" = (
+/obj/structure/interactive/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/tile/chapel,
+/area/mission/prefab/house/house_D03/chapple)
+"Dr" = (
+/obj/structure/interactive/door/airlock/wood,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"DK" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"EL" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/hallway)
+"Fd" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/sec)
+"Fm" = (
+/obj/structure/interactive/power/apc,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03)
+"Fv" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/sec)
+"Gb" = (
+/obj/structure/table/reinforced/steel,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"Gc" = (
+/turf/dmm_suite/no_wall,
+/area/dmm_suite/clear_area)
+"Gi" = (
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/sec)
+"Gj" = (
+/obj/structure/interactive/bed/sheet,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/sec)
+"Gt" = (
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/hallway)
+"GQ" = (
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"Hg" = (
+/obj/structure/interactive/door/airlock/station/glass,
+/turf/simulated/floor/tile/chapel,
+/area/mission/prefab/house/house_D03/chapple)
+"HA" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/food,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"HD" = (
+/turf/dmm_suite/clear_turf,
+/area/dmm_suite/clear_area)
+"HJ" = (
+/obj/structure/interactive/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/tile/chapel/decor{
+	dir = 1
+	},
+/area/mission/prefab/house/house_D03/chapple)
+"HZ" = (
+/obj/marker/map_node,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"IY" = (
+/obj/structure/interactive/light_switch{
+	icon_state = "setup";
+	dir = 1
+	},
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/sec)
+"JE" = (
+/obj/structure/table/rack/grey,
+/obj/item/weapon/melee/tool/screwdriver,
+/obj/item/weapon/melee/tool/welder,
+/obj/item/weapon/melee/tool/multitool,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"JQ" = (
+/obj/structure/interactive/door/airlock/station,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"Lh" = (
+/obj/structure/interactive/solar_panel,
+/obj/structure/interactive/wire/yellow,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03)
+"Lw" = (
+/obj/marker/spawning/window,
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03)
+"Lz" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/command)
+"Nv" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03)
+"NJ" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03)
+"On" = (
+/obj/structure/interactive/crate/closet,
+/obj/marker/spawning/random/misc,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"OU" = (
+/obj/structure/table/wood,
+/obj/marker/spawning/random/misc,
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/tile/chapel/decor{
+	dir = 4
+	},
+/area/mission/prefab/house/house_D03/chapple)
+"Pc" = (
+/obj/structure/interactive/wire/red,
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03)
+"Ph" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/hallway)
+"Qd" = (
+/obj/structure/interactive/bed/sheet,
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"Qu" = (
+/obj/structure/interactive/light_switch,
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/chapple)
+"RD" = (
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/science)
+"Sr" = (
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D03/command)
+"Su" = (
+/obj/structure/interactive/light_switch{
+	dir = 4;
+	icon_state = "setup"
+	},
+/turf/simulated/wall/metal,
+/area/mission/prefab/house/house_D03/command)
+"SO" = (
+/turf/simulated/floor/tile/grey,
+/area/mission/prefab/house/house_D03/command)
+"TS" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"VA" = (
+/obj/structure/table/rack/grey,
+/obj/marker/spawning/random/misc,
+/obj/structure/interactive/lighting/fixture/bulb,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/sec)
+"VD" = (
+/obj/structure/interactive/chair/wood{
+	icon_state = "wooden_chair";
+	dir = 4
+	},
+/turf/simulated/floor/tile/grey/ish,
+/area/mission/prefab/house/house_D03/command)
+"VI" = (
+/obj/structure/interactive/crate/trash,
+/obj/marker/spawning/random/trash,
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"VQ" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	icon_state = "preview";
+	dir = 4
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"WH" = (
+/obj/structure/interactive/wire/yellow,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03)
+"Xr" = (
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03)
+"YF" = (
+/obj/structure/interactive/lighting/fixture/bulb{
+	dir = 1
+	},
+/turf/simulated/floor/wood/brown,
+/area/mission/prefab/house/house_D03/hallway)
+"Zv" = (
+/turf/simulated/wall/wood/brown,
+/area/mission/prefab/house/house_D03/chapple)
+"Zx" = (
+/obj/marker/spawning/window,
+/turf/simulated/floor/plating,
+/area/mission/prefab/house/house_D03/chapple)
+
+(1,1,1) = {"
+HD
+HD
+HD
+HD
+TS
+Ph
+TS
+me
+me
+cy
+Ph
+Ph
+TS
+Gc
+Gc
+Gc
+"}
+(2,1,1) = {"
+HD
+br
+br
+br
+TS
+jc
+VQ
+pW
+pW
+pW
+pW
+VI
+Ph
+Lh
+WH
+Lh
+"}
+(3,1,1) = {"
+HD
+br
+lU
+hk
+HZ
+pW
+pW
+pW
+HZ
+pW
+pW
+HZ
+Ph
+Lh
+WH
+Lh
+"}
+(4,1,1) = {"
+Fd
+br
+xy
+br
+pW
+Sr
+Su
+Lz
+JQ
+Sr
+Sr
+pW
+Ph
+op
+Xr
+Lh
+"}
+(5,1,1) = {"
+Fd
+Gj
+Gi
+si
+pW
+Lz
+fx
+mF
+SO
+AN
+Sr
+YF
+TS
+Lw
+oY
+NJ
+"}
+(6,1,1) = {"
+Fd
+si
+eC
+Fd
+pW
+Lz
+lM
+SO
+VD
+fn
+Sr
+pW
+tO
+bO
+Nv
+NJ
+"}
+(7,1,1) = {"
+Fd
+VA
+qQ
+vK
+HZ
+Lz
+fx
+tv
+aF
+wg
+Sr
+pW
+NJ
+CW
+NJ
+NJ
+"}
+(8,1,1) = {"
+Fd
+wr
+Fv
+IY
+pW
+Lz
+AN
+SO
+HA
+lW
+Sr
+pW
+Fm
+Pc
+JE
+NJ
+"}
+(9,1,1) = {"
+Fd
+CQ
+Fv
+Fd
+BJ
+Lz
+vz
+mF
+SO
+AG
+Sr
+pW
+oY
+GQ
+dP
+NJ
+"}
+(10,1,1) = {"
+Fd
+Fd
+Fd
+Fd
+pW
+Sr
+Sr
+Lz
+JQ
+Sr
+Sr
+pW
+oY
+GQ
+Gb
+NJ
+"}
+(11,1,1) = {"
+HD
+TS
+Gt
+su
+HZ
+pW
+pW
+pW
+pW
+pW
+pW
+HZ
+ng
+An
+Ak
+NJ
+"}
+(12,1,1) = {"
+HD
+TS
+EL
+vG
+Zv
+Zv
+Qu
+pW
+pW
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+"}
+(13,1,1) = {"
+TS
+TS
+EL
+Zv
+HJ
+uJ
+Zx
+pW
+YF
+dX
+AP
+aQ
+Qd
+aQ
+gl
+dX
+"}
+(14,1,1) = {"
+TS
+qE
+EL
+Zv
+OU
+rq
+Zx
+pW
+HZ
+Dr
+RD
+RD
+vv
+RD
+RD
+sc
+"}
+(15,1,1) = {"
+su
+EL
+EL
+Qu
+Dm
+Dm
+Hg
+pW
+pW
+dX
+On
+sH
+On
+sH
+On
+dX
+"}
+(16,1,1) = {"
+TS
+DK
+TS
+Zv
+Zv
+Zv
+Zv
+me
+me
+dX
+dX
+dX
+dX
+dX
+dX
+dX
+"}


### PR DESCRIPTION
# What this PR does
Adds 3 new prefabs
1: Type C (D01), c shaped house with 2 bedrooms and a small maintenance hallway in the middle, 5 survivors
![d01](https://user-images.githubusercontent.com/59121922/187823618-bf018667-a04d-44d9-b321-ba424a67ded7.PNG)

1: homeless person Barracks (D02), a homeless shelter turned into a barracks for the survivors, features a fullbody window in the bathroom for maximum visibility when you are at your weakest, 7 survivors 
(NOTICE, has 3 guns that spawn with the map, put them there so the place actually looks like a barracks rather then just a homeless shelter with hostile survivors)
![d02](https://user-images.githubusercontent.com/59121922/187823653-d71826b9-ffad-4e65-bd49-ba18242a9f71.PNG)


3: "Boxed in" (D03), a familiar design in a strangers home, 4 survivors
![d03](https://user-images.githubusercontent.com/59121922/187823666-343280e8-5eb1-4175-b4f0-e6a774bf770f.PNG)

# Why it should be added to the game
more prefabs as you requested, sire!

(also, pls give me contributor role I still haven't gotten it after I added the Steve armor and grenade launcher many moons ago ☹️  )

