### PR TITLE
Adds an enemy pinpointer for new players

### DIFF
--- a/code/_core/obj/item/clothing/back/storage/satchel/_satchel.dm
+++ b/code/_core/obj/item/clothing/back/storage/satchel/_satchel.dm
@@ -21,6 +21,7 @@
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/storage/emergency(src)
 	new /obj/item/pinpointer/landmark(src)
+	new /obj/item/pinpointer/mobs(src)
 	new /obj/item/clothing/overwear/coat/hoodie/grey(src)
 	new /obj/item/weapon/melee/torch/flashlight(src)
 	new /obj/item/weapon/ranged/bullet/revolver/detective(src)

--- a/code/_core/obj/item/pinpointer.dm
+++ b/code/_core/obj/item/pinpointer.dm
@@ -10,6 +10,8 @@
 
 	var/scan_mode = FALSE
 
+	var/signal_offset
+
 	value = 10
 
 	weight = 2
@@ -392,9 +394,6 @@
 	contraband = TRUE
 	unreliable = TRUE
 
-
-var/global/signal_offset = rand(0,10000)
-
 /obj/item/pinpointer/deathmatch/click_self(var/mob/caller)
 
 	INTERACT_CHECK
@@ -427,6 +426,48 @@ var/global/signal_offset = rand(0,10000)
 	if(choice)
 		var/mob/living/advanced/player/P = possible_crew[choice]
 		tracked_atom = P
+	else
+		tracked_atom = null
+
+	scan_mode = FALSE
+	START_THINKING(src)
+
+	return TRUE
+
+
+
+/obj/item/pinpointer/mobs
+	name = "enemy pinpointer"
+	desc_extended = "Use this to track and locate objects. This one tracks things to kill."
+	icon_state = "syndicate"
+	value = 1000
+	value_burgerbux = 1
+
+/obj/item/pinpointer/mobs/click_self(var/mob/caller, var/mob/living/advanced/npc/a, var/mob/living/simple/a)
+	INTERACT_CHECK
+	INTERACT_DELAY(1)
+
+	var/list/mobs = list()
+	for(a in all_mobs)
+		if(!can_track(a))
+			continue
+		var/signal_num = text2num("\ref[a]",16)
+		signal_num += signal_offset
+		signal_num = 1 + (signal_num % 200)
+		var/distance_to_show = get_dist_advanced(src,a)
+		var/name_mod = "[a.name] ([a.dead ? "DEAD" : "Alive"], ~[distance_to_show]m)"
+		mobs[name_mod] = a
+
+	scan_mode = TRUE
+	update_sprite()
+
+	var/choice = input("Who do you want to track?","Mob Pinpointer Tracking",null) as null|anything in mobs
+
+	INTERACT_CHECK_OTHER(src) //Hacky
+
+	if(choice)
+		a = mobs[choice]
+		tracked_atom = a
 	else
 		tracked_atom = null
 


### PR DESCRIPTION
# What this PR does
Exactly as the title says, adds a pinpointer which tracks mobs and advanced AI on the current Zlevel to MURDER 
![image](https://user-images.githubusercontent.com/61367602/192126140-6feb8eb3-acb6-4e46-bd25-b382c3ebf698.png)
*yes I know the box says DEATHMATCH pinpointer, that was a screenshot before it was finished and I'll be damned if i'm **re-compiling just to get a new screenshot**)


# Why it should be added to the game
requested feature, and a pretty damn good one