### PR TITLE
Deletes exactly 2 bug?(s)

### DIFF
--- a/code/_core/obj/item/spellswap/_spellswap.dm
+++ b/code/_core/obj/item/spellswap/_spellswap.dm
@@ -30,7 +30,7 @@
 			return TRUE
 
 		if(I.stored_spellswap)
-			qdel(I)
+			qdel(I.stored_spellswap)
 
 		src.drop_item(I)
 		I.stored_spellswap = src

--- a/code/_core/obj/item/weapon/ranged/wand/_wand.dm
+++ b/code/_core/obj/item/weapon/ranged/wand/_wand.dm
@@ -178,12 +178,15 @@
 /obj/item/weapon/ranged/wand/save_item_data(var/mob/living/advanced/player/P,var/save_inventory = TRUE,var/died=FALSE)
 	. = ..()
 	SAVEATOM("socketed_spellgem")
+	SAVEVAR("sockets")
 	SAVELISTATOM("socketed_supportgems")
 
 /obj/item/weapon/ranged/wand/load_item_data_post(var/mob/living/advanced/player/P,var/list/object_data)
 	. = ..()
 	LOADATOM("socketed_spellgem")
+	LOADVAR("sockets")
 	LOADLISTATOM("socketed_supportgems")
+	
 
 /obj/item/weapon/ranged/wand/shoot(var/mob/caller,var/atom/object,location,params,var/damage_multiplier=1,var/click_called=FALSE)
 	if(!socketed_spellgem)


### PR DESCRIPTION
# What this PR does
Causes spellswapping a spellswapped item to Qdel the old spellswap instead of the item itself
Makes staffs remember how many slots they have on save/load

# Why it should be added to the game

Not funni bug bad, funni bug acceptable.

These two not funni.