### PR TITLE
Lays out the foundation of the Voice Of God Ability Package

### DIFF
--- a/code/__defines/status.dm
+++ b/code/__defines/status.dm
@@ -99,3 +99,7 @@
 #define IMMORTAL "immortal"
 
 #define CRITPROTECTION "critprotection"
+
+#define FRAGILE "fragile"
+//Increases the damage multiplier, which increases incoming damage.
+//The strongest stack takes priority, but all instances will refresh the effect.

--- a/code/_core/datum/ability/voice_of_god.dm
+++ b/code/_core/datum/ability/voice_of_god.dm
@@ -1,0 +1,73 @@
+/ability/voice_of_god/harm
+	name = "Command: Harm"
+	desc = "Damages all enemies within 8 tiles, and makes them susceptable to further damage."
+	icon_state = "dash"
+
+	resource_type = MANA
+	var/damagetype/damage_type
+	var/atom/caller
+	var/word = "DIE"
+	category = "Voice Of God"
+
+/ability/voice_of_god/harm/proc/get_params(var/atom/victim)
+	. = list()
+	.[PARAM_ICON_X] = rand(0,32)
+	.[PARAM_ICON_Y] = rand(0,32)
+
+/ability/voice_of_god/harm/proc/do_damage(var/atom/victim,var/atom/caller)
+
+	if(is_living(victim) && is_living(caller) && caller != victim)
+		var/mob/living/L = victim
+		var/mob/living/L2 = caller
+		if(!allow_hostile_action(L2.loyalty_tag,L))
+			return FALSE
+	var/damagetype/DT = all_damage_types[damage_type]
+	var/list/params = get_params()
+	if(!victim.can_be_attacked(caller,src,params,DT))
+		return FALSE
+	var/atom/object_to_damage = victim.get_object_to_damage(caller,src,damage_type,params,TRUE,TRUE)
+	return DT.process_damage(caller,victim,src,object_to_damage,caller,1)
+
+/ability/voice_of_god/harm/on_cast(var/mob/caller,var/atom/target,var/atom/victim,location,params)
+
+	var/mob/living/L = caller
+	var/turf/T = get_turf(L)
+	play_sound('sound/effects/invoke_general.ogg',T, range_max = SOUND_RANGE)
+	L.do_say("<font color='#DD1C1F' size='4'>[word]</font>",FALSE)
+
+	for(var/mob/living/L2 in oview(T,8))
+	//	if(L2.dead)
+	//		continue
+	//	if(L2.loyalty_tag == L.loyalty_tag)
+	//		continue
+		do_damage(L2,L)
+
+/ability/voice_of_god/harm/bleed
+	name = "Command: Bleed"
+	desc = "Open wounds in all enemies within 8 tiles."
+	cost = 50
+	cooldown = SECONDS_TO_DECISECONDS(10)
+	damage_type = /damagetype/ranged/magic/voice_of_god/bleed
+	word = "BLEED"
+
+/ability/voice_of_god/live
+	name = "Command: Live"
+	desc = "Heal all allied listeners within 8 tiles, as well as staving off death for 5 seconds."
+	cost = 50
+	cooldown = SECONDS_TO_DECISECONDS(15)
+	category = "Voice Of God"
+	var/word = "LIVE" //Is there possibly a way to switch what a specific ability does? Well, seeing as this one's the area buff while the others are area debuffs...
+	var/leveled_effect = 0
+
+/ability/voice_of_god/live/on_cast(var/mob/caller,var/atom/target,var/atom/victim,location,params)
+
+	var/mob/living/L = caller
+	var/turf/T = get_turf(L)
+
+	for(var/mob/living/L2 in oview(T,4))
+		if(L2.dead)
+			continue
+		if(L2.loyalty_tag != L.loyalty_tag)
+			continue
+		L2.add_status_effect(TEMP_REGEN,2,SECONDS_TO_DECISECONDS(5))
+		L2.add_status_effect(UNDYING,SECONDS_TO_DECISECONDS(5))

--- a/code/_core/datum/ability/voice_of_god.dm
+++ b/code/_core/datum/ability/voice_of_god.dm
@@ -36,10 +36,10 @@
 	L.do_say("<font color='#DD1C1F' size='4'>[word]</font>",FALSE)
 
 	for(var/mob/living/L2 in oview(T,8))
-	//	if(L2.dead)
-	//		continue
-	//	if(L2.loyalty_tag == L.loyalty_tag)
-	//		continue
+		if(L2.dead)
+			continue
+		if(L2.loyalty_tag == L.loyalty_tag)
+			continue
 		do_damage(L2,L)
 
 /ability/voice_of_god/harm/bleed

--- a/code/_core/datum/ability/voice_of_god.dm
+++ b/code/_core/datum/ability/voice_of_god.dm
@@ -2,9 +2,10 @@
 	name = "Command: Harm"
 	desc = "Damages all enemies within 8 tiles, and makes them susceptable to further damage."
 	icon_state = "dash"
-
 	resource_type = MANA
-	var/damagetype/damage_type
+	cost = 50 //Half of a level 1 character's mana. Has a high cooldown.
+	cooldown = SECONDS_TO_DECISECONDS(10)
+	var/damagetype/damage_type = /damagetype/ranged/magic/voice_of_god/harm
 	var/atom/caller
 	var/word = "DIE"
 	category = "Voice Of God"
@@ -33,7 +34,7 @@
 	for(var/mob/living/L2 in oview(T,8))
 		if(L2.dead)
 			continue
-		if(!allow_hostile_action(L.loyalty_tag,L2))
+		if(!allow_hostile_action(L2.loyalty_tag,L))		
 			continue
 		do_damage(L2,L)
 
@@ -58,11 +59,14 @@
 
 	var/mob/living/L = caller
 	var/turf/T = get_turf(L)
+	play_sound('sound/effects/invoke_general.ogg',T, range_max = SOUND_RANGE)
+	leveled_effect = round(L.get_skill_power(SKILL_PRAYER,0,1,2))
 
-	for(var/mob/living/L2 in oview(T,4))
+	L.do_say("<font color='#DD1C1F' size='4'>[word]</font>",FALSE)
+	for(var/mob/living/L2 in oview(T,8))
 		if(L2.dead)
 			continue
 		if(L2.loyalty_tag != L.loyalty_tag)
 			continue
-		L2.add_status_effect(TEMP_REGEN,2,SECONDS_TO_DECISECONDS(5))
+		L2.add_status_effect(TEMP_REGEN,leveled_effect,SECONDS_TO_DECISECONDS(5))
 		L2.add_status_effect(UNDYING,SECONDS_TO_DECISECONDS(5))

--- a/code/_core/datum/ability/voice_of_god.dm
+++ b/code/_core/datum/ability/voice_of_god.dm
@@ -16,11 +16,6 @@
 
 /ability/voice_of_god/harm/proc/do_damage(var/atom/victim,var/atom/caller)
 
-	if(is_living(victim) && is_living(caller) && caller != victim)
-		var/mob/living/L = victim
-		var/mob/living/L2 = caller
-		if(!allow_hostile_action(L2.loyalty_tag,L))
-			return FALSE
 	var/damagetype/DT = all_damage_types[damage_type]
 	var/list/params = get_params()
 	if(!victim.can_be_attacked(caller,src,params,DT))
@@ -38,7 +33,7 @@
 	for(var/mob/living/L2 in oview(T,8))
 		if(L2.dead)
 			continue
-		if(L2.loyalty_tag == L.loyalty_tag)
+		if(!allow_hostile_action(L.loyalty_tag,L2))
 			continue
 		do_damage(L2,L)
 

--- a/code/_core/datum/ability/voice_of_god.dm
+++ b/code/_core/datum/ability/voice_of_god.dm
@@ -2,6 +2,7 @@
 	name = "Command: Harm"
 	desc = "Damages all enemies within 8 tiles, and makes them susceptable to further damage."
 	icon_state = "dash"
+
 	resource_type = MANA
 	cost = 50 //Half of a level 1 character's mana. Has a high cooldown.
 	cooldown = SECONDS_TO_DECISECONDS(10)
@@ -53,14 +54,16 @@
 	cooldown = SECONDS_TO_DECISECONDS(15)
 	category = "Voice Of God"
 	var/word = "LIVE" //Is there possibly a way to switch what a specific ability does? Well, seeing as this one's the area buff while the others are area debuffs...
-	var/leveled_effect = 0
+	var/leveled_effect = 1
 
 /ability/voice_of_god/live/on_cast(var/mob/caller,var/atom/target,var/atom/victim,location,params)
 
 	var/mob/living/L = caller
 	var/turf/T = get_turf(L)
 	play_sound('sound/effects/invoke_general.ogg',T, range_max = SOUND_RANGE)
-	leveled_effect = round(L.get_skill_power(SKILL_PRAYER,0,1,2))
+	
+	if(is_living(L))
+		leveled_effect = round(L.get_skill_power(SKILL_PRAYER,0,1,2)*5)
 
 	L.do_say("<font color='#DD1C1F' size='4'>[word]</font>",FALSE)
 	for(var/mob/living/L2 in oview(T,8))

--- a/code/_core/datum/damagetype/ranged/magic/voice_of_god.dm
+++ b/code/_core/datum/damagetype/ranged/magic/voice_of_god.dm
@@ -1,0 +1,40 @@
+/damagetype/ranged/magic/voice_of_god/harm
+	attack_damage_base = list(
+		HOLY = 60*0.25
+	)
+
+	skill_stats = list(
+		SKILL_PRAYER = 60*0.25
+	)
+
+	skill_damage = list(
+		SKILL_PRAYER = HOLY
+	)
+
+/damagetype/ranged/magic/voice_of_god/bleed
+	attack_damage_base = list(
+		BLADE = 60*0.125,
+		HOLY = 60*0.125 //30 damage base
+	)
+
+	skill_stats = list(
+		SKILL_PRAYER = 60*0.25,
+	)
+
+	skill_damage = list(
+		SKILL_PRAYER = list(BLADE,HOLY)
+	)
+
+	bonus_experience_skill = list(
+		SKILL_MAGIC_OFFENSIVE = 75 //75%
+	)
+
+/damagetype/ranged/magic/voice_of_god/bleed/post_on_hit(var/atom/attacker,var/atom/victim,var/atom/weapon,var/atom/hit_object,var/atom/blamed,var/total_damage_dealt=0)
+	if(is_living(victim))
+		var/mob/living/L = victim
+		var/turf/T = get_turf(L)
+		if(L.blood_type)
+			var/reagent/R = REAGENT(L.blood_type)
+			for(var/i=1,i<=rand(3,5),i++)
+				create_blood(/obj/effect/cleanable/blood/splatter/,T,R.color,rand(-TILE_SIZE*3,TILE_SIZE*3),rand(-TILE_SIZE*3,TILE_SIZE*3))
+	return ..()

--- a/code/_core/datum/status_effect/fragile.dm
+++ b/code/_core/datum/status_effect/fragile.dm
@@ -1,0 +1,18 @@
+/status_effect/fragile //NOTE: DOES NOT WORK. MIGHT BE DUE TO A FAULTY UNDERSTANDING OF CODE.
+	name = "Fragile"
+	desc = "Everything hurts more!"
+	id = FRAGILE
+	minimum = SECONDS_TO_DECISECONDS(1)
+	maximum = SECONDS_TO_DECISECONDS(10)
+
+	default_duration = SECONDS_TO_DECISECONDS(1)
+	default_magnitude = 5 //(1.5x damage)
+
+	affects_dead = FALSE
+
+/status_effect/fragile/on_effect_added(var/mob/living/owner,var/atom/source,var/magnitude,var/duration,var/stealthy)
+	. = ..()
+	if(!owner.health)
+		return
+	owner.health.damage_multiplier *= magnitude
+	owner.health.get_damage_multiplier()


### PR DESCRIPTION
# What this PR does
Open's pandora's box. 

Adds a bunch of abilities that (at the very least) cause status effects to enemies that enhance the damage dealt to them, as well as providing an ability that heals allies (and staves off their deaths).

Prayer will have influence over the power of this ability set.

# Why it should be added to the game
More ability variety is nice. More customizability is nice.

# To do:
-Find a non-jank way to call the damage check
-Figure out what status effect Bleed should do
-Implement a status for Harm
-Figure out how laggy this will end up being
-Figure out how to add an exemption for abilities in the same catagory
-Figure out how to avoid the credit.