### PR TITLE
O r e system attempt 2: Electric Boogaloo

### DIFF
--- a/burgerstation.dme
+++ b/burgerstation.dme
@@ -2333,6 +2333,7 @@
 #include "code\_core\world\subsystems\material.dm"
 #include "code\_core\world\subsystems\menus.dm"
 #include "code\_core\world\subsystems\objs.dm"
+#include "code\_core\world\subsystems\ore.dm"
 #include "code\_core\world\subsystems\paper.dm"
 #include "code\_core\world\subsystems\payday.dm"
 #include "code\_core\world\subsystems\poster.dm"

--- a/code/_core/obj/structure/interactive/mining_drill.dm
+++ b/code/_core/obj/structure/interactive/mining_drill.dm
@@ -120,10 +120,7 @@
 		drill_counter++
 		if(drill_counter > 60)
 			found_deposit.drop_ore()
-			found_deposit.ore_count--
 			if(found_deposit.ore_count <= 0 )
-				qdel(found_deposit)
-				src.visible_message(span("warning","The [found_deposit.name] runs dry!"))
 				found_deposit = null
 				deactivate()
 			drill_counter = 0

--- a/code/_core/obj/structure/interactive/ore_deposit.dm
+++ b/code/_core/obj/structure/interactive/ore_deposit.dm
@@ -6,43 +6,27 @@
 	icon_state = "deposit"
 	initialize_type = INITIALIZE_LATE
 	layer = LAYER_WALL_DECAL
+	mouse_opacity = 0
 	var/obj/item/material/ore/stored_ore //We don't need to spawn this yet.
 	var/ore_max = 5 // How much can the vein hold?
-	var/deep_ore_max = 100 //How much does a deep-vein hold? - the thrombosis.
+	var/deep_ore_max = 50 //How much does a deep-vein hold? - the thrombosis.
 	var/ore_count = 0 // How much does it hold currently
 	alpha = 200
 
-/obj/structure/interactive/ore_deposit/clicked_on_by_object(var/mob/caller,var/atom/object,location,control,params)
+/obj/structure/interactive/ore_deposit/Destroy()
+	drop_ore(src,src.stored_ore,src.ore_count)
+	. = ..()
 
-	INTERACT_CHECK
-	if(is_advanced(caller))
-		var/mob/living/advanced/A = caller
-
-		if(!is_item(object))
-			A.to_chat(span("notice","You need a mining tool in order to mine \the [src.name]."))
-			return TRUE
-
-		var/obj/item/I = object
-
-		if(!(I.flags_tool & FLAG_TOOL_PICKAXE))
-			A.to_chat(span("notice","You need a mining tool in order to mine \the [src.name]."))
-			return TRUE
-
-		src.drop_ore(A,stored_ore)
-		ore_count--
-		if(ore_count <= 0)
-			A.to_chat(span("notice", "The [name] runs dry!"))
-			qdel(src)
-		INTERACT_DELAY(I.tool_time)
-
-	return TRUE
-
-/obj/structure/interactive/ore_deposit/proc/drop_ore(var/atom/caller,var/ore_to_spawn)
+/obj/structure/interactive/ore_deposit/proc/drop_ore(var/atom/caller,var/ore_to_spawn,var/ore_amount = 1)
 	var/obj/item/TO = new src.stored_ore
 	var/obj/structure/interactive/ore_box/OB = locate() in orange(2,src)
 	INITIALIZE(TO)
 	GENERATE(TO)
 	FINALIZE(TO)
+	if(ore_amount >= 1)
+		TO.amount = ore_amount
+	else
+		TO.amount = 1
 	if(OB)
 		TO.drop_item(OB.loc)
 	else if(is_living(caller))
@@ -87,8 +71,8 @@
 	desc_extended = "A vein of ore. This one contains iron ore."
 	icon_state = "deposit_iron"
 	stored_ore = /obj/item/material/ore/iron
-	ore_max = 20
-	deep_ore_max = 800
+	ore_max = 10
+	deep_ore_max = 200
 
 /obj/structure/interactive/ore_deposit/copper
 	name = "copper deposit"
@@ -96,8 +80,8 @@
 	desc_extended = "A vein of ore. This one contains copper ore."
 	color = "#E28446"
 	stored_ore = /obj/item/material/ore/copper
-	ore_max = 14
-	deep_ore_max = 560
+	ore_max = 7
+	deep_ore_max = 140
 
 /obj/structure/interactive/ore_deposit/tin
 	name = "tin deposit"
@@ -105,8 +89,8 @@
 	desc_extended = "A vein of ore. This one contains tin ore."
 	color = "#E2E2E2"
 	stored_ore = /obj/item/material/ore/tin
-	ore_max = 14
-	deep_ore_max = 560
+	ore_max = 7
+	deep_ore_max = 140
 
 /obj/structure/interactive/ore_deposit/zinc
 	name = "zinc deposit"
@@ -114,8 +98,8 @@
 	desc_extended = "A vein of ore. This one contains zinc ore."
 	color = "#E8E8EF"
 	stored_ore = /obj/item/material/ore/zinc
-	ore_max = 12
-	deep_ore_max = 500
+	ore_max = 6
+	deep_ore_max = 125
 
 /obj/structure/interactive/ore_deposit/gold
 	name = "gold deposit"
@@ -123,8 +107,8 @@
 	desc_extended = "A vein of ore. This one contains gold ore."
 	icon_state = "deposit_gold"
 	stored_ore = /obj/item/material/ore/gold
-	ore_max = 10
-	deep_ore_max = 400
+	ore_max = 5
+	deep_ore_max = 100
 
 /obj/structure/interactive/ore_deposit/uranium
 	name = "uranium deposit"
@@ -132,16 +116,16 @@
 	desc_extended = "A vein of ore. This one contains uranium ore."
 	icon_state = "deposit_uranium"
 	stored_ore = /obj/item/material/ore/uranium
-	ore_max = 10
-	deep_ore_max = 500
+	ore_max = 5
+	deep_ore_max = 125
 
 /obj/structure/interactive/ore_deposit/titanium
 	name = "titanium deposit"
 	desc = "Float like a butterfly."
 	desc_extended = "A vein of ore. This one contains titanium ore."
 	stored_ore = /obj/item/material/ore/titanium
-	ore_max = 6
-	deep_ore_max = 400
+	ore_max = 3
+	deep_ore_max = 100
 
 /obj/structure/interactive/ore_deposit/silver
 	name = "silver deposit"
@@ -149,8 +133,8 @@
 	desc_extended = "A vein of ore. This one contains silver ore."
 	icon_state = "deposit_silver"
 	stored_ore = /obj/item/material/ore/silver
-	ore_max = 10
-	deep_ore_max = 400
+	ore_max = 5
+	deep_ore_max = 100
 
 /obj/structure/interactive/ore_deposit/carbon
 	name = "coal deposit"
@@ -159,7 +143,7 @@
 	icon_state = "deposit_coal"
 	stored_ore = /obj/item/material/ore/carbon
 	ore_max = 6
-	deep_ore_max = 80
+	deep_ore_max = 200
 
 /obj/structure/interactive/ore_deposit/magnesium
 	name = "magnesium deposit"
@@ -167,7 +151,7 @@
 	desc_extended = "A vein of ore. This one contains magnesium ore."
 	stored_ore = /obj/item/material/ore/magnesium
 	ore_max = 6
-	deep_ore_max = 240
+	deep_ore_max = 80
 
 /obj/structure/interactive/ore_deposit/aluminium
 	name = "aluminium deposit"
@@ -176,7 +160,7 @@
 	stored_ore = /obj/item/material/ore/aluminium
 	color = "#C4C4C4"
 	ore_max = 6
-	deep_ore_max = 240
+	deep_ore_max = 80
 
 /obj/structure/interactive/ore_deposit/nickel
 	name = "nickel deposit"
@@ -184,7 +168,7 @@
 	desc_extended = "A vein of ore. This one contains nickel ore."
 	stored_ore = /obj/item/material/ore/nickel
 	ore_max = 6
-	deep_ore_max = 240
+	deep_ore_max = 80
 
 /obj/structure/interactive/ore_deposit/plasma
 	name = "phoron plasma deposit"
@@ -193,7 +177,7 @@
 	icon_state = "deposit_phoron"
 	stored_ore = /obj/item/material/ore/plasma
 	ore_max = 6
-	deep_ore_max = 160
+	deep_ore_max = 80
 
 /obj/structure/interactive/ore_deposit/diamond
 	name = "diamond deposit"
@@ -202,7 +186,7 @@
 	icon_state = "deposit_diamond"
 	stored_ore = /obj/item/material/ore/diamond
 	ore_max = 6
-	deep_ore_max = 160
+	deep_ore_max = 80
 
 /obj/structure/interactive/ore_deposit/cobalt
 	name = "cobalt deposit"
@@ -211,7 +195,7 @@
 	color =	COLOR_BLUE
 	stored_ore = /obj/item/material/ore/cobalt
 	ore_max = 6
-	deep_ore_max = 240
+	deep_ore_max = 120
 //deep ore
 /obj/structure/interactive/ore_deposit_ground
 	name = "deep ore deposit"
@@ -223,17 +207,11 @@
 	var/ore_count = 0 // How much does it hold currently
 	initialize_type = INITIALIZE_LATE
 
-/obj/structure/interactive/ore_deposit_ground/clicked_on_by_object(mob/caller, atom/object, location, control, params)
-	caller.to_chat(span("notice","This vein is far too deep to mine manually! You should get a Drill to do it for you!"))
-	return TRUE
-
 /obj/structure/interactive/ore_deposit_ground/proc/drop_ore(var/caller,var/ore_to_spawn)
 
 	var/obj/structure/interactive/mining_drill/MD = locate() in range(1,src)
 	var/obj/structure/interactive/ore_box/OB = locate() in orange(1,src)
 	var/obj/structure/interactive/conveyor/CV = locate() in orange(1,src)
-	if(!MD)
-		CRASH("Who the fuck called drop_ore on a deep vein without a drill? [caller] did.")
 	var/obj/item/TO = new src.stored_ore
 	INITIALIZE(TO)
 	GENERATE(TO)
@@ -242,8 +220,15 @@
 		TO.drop_item(CV.loc)
 	else if(OB)
 		TO.drop_item(OB.loc)
+	else if (!MD)
+		log_error("[caller] called 'drop_ore' on a deep vein while there isnt a drill! Bad! Dropping at src.loc,AKA:[src.loc]")
+		TO.drop_item(src.loc)
 	else
 		TO.drop_item(MD.loc)
+	ore_count--
+	if(ore_count <= 0)
+		src.visible_message(span("warning","The [src.name] runs dry!"))
+		qdel(src)
 
 /obj/structure/interactive/ore_deposit_ground/random
 

--- a/code/_core/world/subsystems/ore.dm
+++ b/code/_core/world/subsystems/ore.dm
@@ -15,30 +15,18 @@ SUBSYSTEM_DEF(ore)
 	for(var/turf/simulated/floor/S in block(startturf,endturf))
 		if(!S.organic)
 			continue
-		if(SSdmm_suite.is_pvp_coord(S.x,S.y,S.z))
-			if(prob(99))
-				continue
-			new /obj/marker/ore_deep(S)
-			spawned_ore_chunks_deep++
-		else
-			if(prob(99.75))
-				continue
-			new /obj/marker/ore_deep(S)
-			spawned_ore_chunks_deep++
+		if(prob(99))
+			continue
+		var/obj/structure/O = new /obj/structure/interactive/ore_deposit_ground/random(S)
+		S.attach(O)
+		spawned_ore_chunks_deep++
 		CHECK_TICK_HARD(DESIRED_TICK_LIMIT)
 	for(var/turf/simulated/wall/rock/S in block(startturf,endturf))
-		if(!S.organic || !S.health)
+		if(prob(97.5))
 			continue
-		if(SSdmm_suite.is_pvp_coord(S.x,S.y,S.z))
-			if(prob(96))
-				continue
-			new /obj/marker/ore(S)
-			spawned_ore_chunks++
-		else
-			if(prob(98))
-				continue
-			new /obj/marker/ore(S)
-			spawned_ore_chunks++
+		var/obj/structure/O = new /obj/structure/interactive/ore_deposit/random(S)
+		S.attach(O)
+		spawned_ore_chunks++
 		CHECK_TICK_HARD(DESIRED_TICK_LIMIT)
 	log_subsystem(name,"Spawned [spawned_ore_chunks] ore chunks and [spawned_ore_chunks_deep] deep veins.")
 


### PR DESCRIPTION
# What this PR does
Re-Enables ore spawning
Reduced total amount of ore per vein
Increased total amount of regular ores.
Ore now uses Turf Attachment system
Ore now "mined" when related turf destroyed/deep drill is over it for normal/deep veins. Deep veins now don't CRASH if something calls 'drop_ore' without a drill on-top of them, instead attempts drop and logs error.
Moves ore depletion and deletion from drill to ore deposit.

# Why it should be added to the game
Last ore attempt I did was quite rushed and somewhat unfinished. Should have it fixed up to acceptable standards. Balancing can be done with further testing OFC. From my limited poor memory, should be somewhat balanced. Tested to ensure all mechanics function as intended.