### PR TITLE
Adds missing armor to NT officer clothing.

### DIFF
--- a/code/_core/obj/item/clothing/pants/nanotrasen_officer.dm
+++ b/code/_core/obj/item/clothing/pants/nanotrasen_officer.dm
@@ -4,6 +4,8 @@
 	desc_extended = "A pair of pants worn by officers of NanoTrasen."
 	icon = 'icons/obj/item/clothing/pants/nanotrasen_officer.dmi'
 
+	armor = /armor/cloth/hard
+
 	value = 150
 
-	rarity = RARITY_RARE
+	rarity = RARITY_UNCOMMON

--- a/code/_core/obj/item/clothing/shirt/nanotrasen_officer.dm
+++ b/code/_core/obj/item/clothing/shirt/nanotrasen_officer.dm
@@ -4,6 +4,8 @@
 	desc_extended = "A shirt worn by officers of NanoTrasen."
 	icon = 'icons/obj/item/clothing/shirts/nanotrasen_officer.dmi'
 
+	armor = /armor/cloth/hard
+
 	value = 150
 
-	rarity = RARITY_RARE
+	rarity = RARITY_UNCOMMON


### PR DESCRIPTION
# What this PR does
Adds armor I forgot to give to the NT officer clothing, also downgrades the rarity from rare to uncommon due to it's presence in the vendors.

# Why it should be added to the game
Brings it in line with other clothing.