### PR TITLE
changes Clown job to be funnier, and removes negative stats

### DIFF
--- a/code/_core/datum/job/clown.dm
+++ b/code/_core/datum/job/clown.dm
@@ -3,7 +3,7 @@
 	desc = "The metaphorical cockroaches of space stations."
 
 	passive_income = 0
-	passive_income_bonus = 1 //Per rank
+	passive_income_bonus = 6 //Per rank
 
 	bonus_skills = list(
 		SKILL_EVASION = 7
@@ -11,7 +11,7 @@
 
 	bonus_attributes = list(
 		ATTRIBUTE_AGILITY = 7,
-		ATTRIBUTE_LUCK = 10,
+		ATTRIBUTE_LUCK = 7,
 		ATTRIBUTE_CONSTITUTION = 7,
 		ATTRIBUTE_VITALITY = 7
 	)

--- a/code/_core/datum/job/clown.dm
+++ b/code/_core/datum/job/clown.dm
@@ -1,47 +1,24 @@
 /job/clown
 	name = "Clown"
-	desc = "Good at not dying, horrible at everything else."
+	desc = "The metaphorical cockroaches of space stations."
 
 	passive_income = 0
-	passive_income_bonus = 0 //Per rank
+	passive_income_bonus = 1 //Per rank
 
 	bonus_skills = list(
-		SKILL_MELEE = -7,
-		SKILL_BLOCK = -7,
-		SKILL_ARMOR = -7,
-		SKILL_SURVIVAL = -7,
-		SKILL_EVASION = 10,
-		SKILL_PRAYER = -7,
-		SKILL_RANGED= -7,
-		SKILL_UNARMED = -7,
-		SKILL_SURVIVAL = -7,
-		SKILL_MAGIC = -7,
-		SKILL_SUMMONING = -7,
-		SKILL_MEDICINE = -7,
-		SKILL_PRECISION = -7,
+		SKILL_EVASION = 5
 	)
 
 	bonus_attributes = list(
-		ATTRIBUTE_STRENGTH = -7,
-		ATTRIBUTE_AGILITY = 10,
-		ATTRIBUTE_LUCK = 15,
-		ATTRIBUTE_RESILIENCE = -7,
-		ATTRIBUTE_ENDURANCE = -7,
-		ATTRIBUTE_CONSTITUTION = 10,
-		ATTRIBUTE_FORTITUDE = -7,
-		ATTRIBUTE_VITALITY = 10,
-		ATTRIBUTE_DEXTERITY = -7,
-		ATTRIBUTE_RESILIENCE = -7,
-		ATTRIBUTE_ENDURANCE = -7,
-		ATTRIBUTE_SOUL = -7,
-		ATTRIBUTE_WILLPOWER = -7,
-		ATTRIBUTE_INTELLIGENCE = -7,
-		ATTRIBUTE_WISDOM = -7,
+		ATTRIBUTE_AGILITY = 5,
+		ATTRIBUTE_LUCK = 10,
+		ATTRIBUTE_CONSTITUTION = 5,
+		ATTRIBUTE_VITALITY = 5
 	)
 
 	ranks = list(
-		"Novice Clown",
-		"Clown",
-		"Expert Clown",
-		"Head of The Circus"
+		"Greenhorn Honker",
+		"Impractical Jester",
+		"Banana Expert",
+		"Circus Ringleader"
 	)

--- a/code/_core/datum/job/clown.dm
+++ b/code/_core/datum/job/clown.dm
@@ -6,14 +6,14 @@
 	passive_income_bonus = 1 //Per rank
 
 	bonus_skills = list(
-		SKILL_EVASION = 5
+		SKILL_EVASION = 7
 	)
 
 	bonus_attributes = list(
-		ATTRIBUTE_AGILITY = 5,
+		ATTRIBUTE_AGILITY = 7,
 		ATTRIBUTE_LUCK = 10,
-		ATTRIBUTE_CONSTITUTION = 5,
-		ATTRIBUTE_VITALITY = 5
+		ATTRIBUTE_CONSTITUTION = 7,
+		ATTRIBUTE_VITALITY = 7
 	)
 
 	ranks = list(


### PR DESCRIPTION
# What this PR does
Removes negative stats from clown, changes the description of the clown to be funnier, and the ranks to be funnier as well.

# Why it should be added to the game
When I made the clown job, I didn't realize the negative stats fucked with so many things, and in hindsight it doesn't fit since none of the other jobs have negative stats. The bonus stats clown gives are now nerfed now to account for this.