### PR TITLE
adds turret ammo to engi ammo vendor

### DIFF
--- a/code/_core/obj/structure/interactive/local_machine/vendor/nanotrasen/nanotrasen_engineering.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/nanotrasen/nanotrasen_engineering.dm
@@ -73,7 +73,9 @@
 		/obj/item/bullet_cartridge/shotgun_12,
 		/obj/item/bullet_cartridge/shotgun_12/flechette,
 		/obj/item/bullet_cartridge/shotgun_12/slug,
-		/obj/item/bullet_cartridge/shotgun_12/frag
+		/obj/item/bullet_cartridge/shotgun_12/frag,
+
+		/obj/item/magazine/minigun_46
 
 	)
 


### PR DESCRIPTION
# What this PR does
Title. Untested.

# Why it should be added to the game
A vendor is in the other room selling turrets, why not add ammo for them in the ammo vendor?