### PR TITLE
adds a phosphorous beaker to chem vendor

### DIFF
--- a/code/_core/obj/item/container/beaker/_beaker.dm
+++ b/code/_core/obj/item/container/beaker/_beaker.dm
@@ -63,6 +63,13 @@
 	reagents.add_reagent(/reagent/potassium,reagents.volume_max)
 	return ..()
 
+/obj/item/container/simple/beaker/phosphorous
+	name = "beaker of phosphorous"
+
+/obj/item/container/simple/beaker/phosphorous/Generate()
+	reagents.add_reagent(/reagent/phosphorous,reagents.volume_max)
+	return ..()
+
 /obj/item/container/simple/beaker/tnt/Generate()
 	reagents.add_reagent(/reagent/fuel/tnt,reagents.volume_max)
 	return ..()

--- a/code/_core/obj/structure/interactive/local_machine/vendor/nanotrasen/nanotrasen_chemistry.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/nanotrasen/nanotrasen_chemistry.dm
@@ -67,7 +67,8 @@
 		/obj/item/container/simple/chemistry/acetone,
 		/obj/item/container/simple/beaker/fuel_cell/phoron,
 		/obj/item/container/simple/chemistry/phenol,
-		/obj/item/container/simple/alcohol/ethanol
+		/obj/item/container/simple/alcohol/ethanol,
+		/obj/item/container/simple/beaker/phosphorous
 	)
 
 	//Missing


### PR DESCRIPTION
# What this PR does
Title.

# Why it should be added to the game
Phosphorous is mostly unobtainable outside of prebuilt smoke grenades. Would be nice<sub>(?)</sub> if we could make our own.