### PR TITLE
Nerfs the Bluespace Satchel to give Bluespace Backpacks more purpose

### DIFF
--- a/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
+++ b/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
@@ -18,9 +18,11 @@
 		/obj/item/clothing/belt/holding
 	)
 
-	value = 3000
+	value = 5000
 
-	value_burgerbux = 1
+	value_burgerbux = 2
+
+	rarity = RARITY_RARE
 
 /obj/item/clothing/back/storage/satchel/bluespace
 	name = "satchel of holding"
@@ -29,7 +31,7 @@
 
 	icon = 'icons/obj/item/clothing/back/satchel/bluespace.dmi'
 
-	dynamic_inventory_count = MAX_INVENTORY_X*4
+	dynamic_inventory_count = 6*4
 	container_max_size = SIZE_4*3
 
 	size = MAX_INVENTORY_X*4*SIZE_4
@@ -45,7 +47,7 @@
 
 	value_burgerbux = 1
 
-	rarity = RARITY_RARE
+	rarity = RARITY_UNCOMMON
 
 /obj/item/clothing/back/storage/satchel/bluespace/prank
 	name = "satchel of hold"
@@ -56,3 +58,7 @@
 	container_max_size = SIZE_9
 
 	size = SIZE_10
+
+	value = 500
+
+	rarity = RARITY_COMMON

--- a/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
+++ b/code/_core/obj/item/clothing/back/storage/bluespace/_bluespace.dm
@@ -31,7 +31,7 @@
 
 	icon = 'icons/obj/item/clothing/back/satchel/bluespace.dmi'
 
-	dynamic_inventory_count = 6*4
+	dynamic_inventory_count = 7*4
 	container_max_size = SIZE_4*3
 
 	size = MAX_INVENTORY_X*4*SIZE_4


### PR DESCRIPTION
# What this PR does

This PR makes the Satchel of Holding able to hold 28 items (7x4 grid) compared to the Bag of Holding's 32 items (8x4 grid).

Additionally, this PR increases the value of Bags of Holding up from 3000 to 5000, and gives them the 'Rare' rarity.
Additionally, this PR makes Satchels of Holding have the 'Uncommon' rarity.
Additionally, this PR makes Satchels of Hold, the prank item, have the 'Common' rarity and decreases their value to 500 to match their prank item status while still holding a little bit of value for use in selling to the shop.

# Why it should be added to the game

Right now, it feels to me like Bags of Holding are just a worse Satchel of Holding in nearly every way, as Satchels have the same storage space (except being unable to carry heavy guns, I think?) while . I got the impression that Satchels of Holding were supposed to at least have less storage slots than the Bag of Holding to give more reason to actually use Bags of Holding over Satchels of Holding.

Satchels of Holding are still very large and can hold more items than rudimentary dufflebags (which have 8x3, or 24 slots), as they themselves are also treasure items, but still have less storage capacity than BoH's along with the inability to store large items.

As Bags of Holding are the largest storage item in the game, I found it odd they were considered 'Common' - probably an oversight, but y'know. Fixed that.