### PR TITLE
Allow the 20mm AMR to take barrel chargers

### DIFF
--- a/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/sniper_20.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/magazine/rifle/sniper_20.dm
@@ -42,6 +42,9 @@
 	attachment_whitelist = list(
 		/obj/item/attachment/barrel/sniper_20 = TRUE,
 
+		/obj/item/attachment/barrel/charger/advanced = TRUE,
+		/obj/item/attachment/barrel/charger/advanced = TRUE,
+
 		/obj/item/attachment/sight/laser_sight = TRUE,
 		/obj/item/attachment/sight/quickfire_adapter = TRUE,
 		/obj/item/attachment/sight/red_dot = TRUE,


### PR DESCRIPTION
# What this PR does
adds the barrel charger and advanced barrel charger to the 20mm sniper's attachment whitelist

# Why it should be added to the game
overkill? more like, just enough kill