### PR TITLE
Allows directly refilling ammo boxes

### DIFF
--- a/code/_core/obj/item/bulletbox.dm
+++ b/code/_core/obj/item/bulletbox.dm
@@ -22,6 +22,7 @@
 	var/draw_bullet_on_box = TRUE
 
 	var/list/obj/item/bullet_cartridge/bullet_whitelist
+	var/is_surplus = FALSE
 
 /obj/item/bulletbox/save_item_data(var/mob/living/advanced/player/P,var/save_inventory = TRUE,var/died=FALSE,var/loadout=FALSE)
 	RUN_PARENT_SAFE
@@ -151,6 +152,7 @@
 		bullet_count = 0
 		bullet_max = 0
 		rarity = RARITY_COMMON
+		is_surplus = FALSE
 		return TRUE
 
 	if(ispath(desired_path))
@@ -159,6 +161,8 @@
 		stored_bullet.amount = 1
 		FINALIZE(stored_bullet)
 		bullet_max = CEILING( 10*(size**3)/stored_bullet.bullet_diameter, 1)
+		if(stored_bullet.rarity == RARITY_BROKEN)
+			is_surplus = TRUE
 		if(!bullet_max)
 			set_stored_bullet(null)
 			update_sprite()

--- a/code/_core/obj/item/bulletbox.dm
+++ b/code/_core/obj/item/bulletbox.dm
@@ -9,6 +9,7 @@
 	var/bullet_max = 0 //Updated when a new bullet is added.
 
 	var/obj/item/bullet_cartridge/stored_bullet //A path.
+	var/obj/item/bullet_cartridge/stored_bullet_original //A path.
 
 	size = SIZE_3
 	weight = 30
@@ -21,13 +22,13 @@
 	var/ignore_custom_sprites = FALSE
 	var/draw_bullet_on_box = TRUE
 
-	var/list/obj/item/bullet_cartridge/bullet_whitelist
-	var/is_surplus = FALSE
+	var/next_regen = 0 //For ammo box restocking.
+
 
 /obj/item/bulletbox/save_item_data(var/mob/living/advanced/player/P,var/save_inventory = TRUE,var/died=FALSE,var/loadout=FALSE)
 	RUN_PARENT_SAFE
 	SAVEVAR("bullet_count")
-	SAVETYPEASPATH("stored_bullet")
+	SAVEPATH("stored_bullet")
 
 /obj/item/bulletbox/load_item_data_pre(var/mob/living/advanced/player/P,var/list/object_data,var/loadout=FALSE)
 	RUN_PARENT_SAFE
@@ -37,8 +38,8 @@
 
 /obj/item/bulletbox/Generate()
 	. = ..()
-	if(ispath(stored_bullet))
-		set_stored_bullet(stored_bullet,generate=TRUE)
+	if(stored_bullet)
+		set_stored_bullet(stored_bullet)
 
 /obj/item/bulletbox/Finalize()
 	. = ..()
@@ -76,9 +77,14 @@
 		INTERACT_DELAY(5)
 		var/obj/item/bullet_cartridge/B = object
 		if(!stored_bullet)
-			if(length(bullet_whitelist) && !bullet_whitelist[B.type])
-				caller.to_chat(span("warning","It would be a bad idea to mix bullets up..."))
-				return TRUE
+			if(ignore_custom_sprites)
+				if(B.type != initial(stored_bullet))
+					caller.to_chat(span("warning","It would be a bad idea to mix bullets up..."))
+					return TRUE
+			else if(stored_bullet)
+				if(B.type != stored_bullet)
+					caller.to_chat(span("warning","It would be a bad idea to mix bullets up..."))
+					return TRUE
 			var/bullets_to_add = min(B.amount,bullet_max)
 			set_stored_bullet(B.type)
 			bullets_to_add = abs(B.add_item_count(-bullets_to_add))
@@ -86,7 +92,7 @@
 			caller.to_chat(span("notice","You add [bullets_to_add] bullet\s to \the [src.name]."))
 			update_sprite()
 			return TRUE
-		if(B.type == stored_bullet.type)
+		if(B.type == stored_bullet)
 			var/bullets_to_add = min(B.amount,bullet_max - bullet_count)
 			if(bullets_to_add <= 0)
 				return TRUE
@@ -111,11 +117,11 @@
 	if(is_inventory(object))
 		INTERACT_CHECK
 		INTERACT_DELAY(5)
-		var/bullets_to_take = min(bullet_count,stored_bullet.amount_max)
+		var/bullets_to_take = min(bullet_count,initial(stored_bullet.amount_max))
 		if(bullets_to_take <= 0)
 			return TRUE
 		var/obj/hud/inventory/I = object
-		var/obj/item/bullet_cartridge/BC = new stored_bullet.type(get_turf(src))
+		var/obj/item/bullet_cartridge/BC = new stored_bullet(get_turf(src))
 		INITIALIZE(BC)
 		BC.amount = bullets_to_take
 		FINALIZE(BC)
@@ -129,7 +135,7 @@
 		INTERACT_CHECK
 		INTERACT_DELAY(5)
 		var/obj/item/magazine/M = object
-		if(!M.can_load_magazine(caller,src.stored_bullet))
+		if(!M.can_load_magazine_path(caller,src.stored_bullet))
 			return TRUE
 		var/bullets_to_take = min(bullet_count,M.bullet_count_max-M.get_ammo_count())
 		if(bullets_to_take <= 0)
@@ -143,33 +149,24 @@
 
 	. = ..()
 
-/obj/item/bulletbox/proc/set_stored_bullet(var/desired_path,var/generate=FALSE)
+/obj/item/bulletbox/proc/set_stored_bullet(var/desired_path)
 
 	if(!desired_path) //Clear and remove.
-		if(stored_bullet && istype(stored_bullet))
-			qdel(stored_bullet)
 		stored_bullet = null
 		bullet_count = 0
 		bullet_max = 0
 		rarity = RARITY_COMMON
-		is_surplus = FALSE
 		return TRUE
 
 	if(ispath(desired_path))
-		stored_bullet = new desired_path(src)
-		INITIALIZE(stored_bullet)
-		stored_bullet.amount = 1
-		FINALIZE(stored_bullet)
-		bullet_max = CEILING( 10*(size**3)/stored_bullet.bullet_diameter, 1)
-		if(stored_bullet.rarity == RARITY_BROKEN)
-			is_surplus = TRUE
+		stored_bullet = desired_path
+		bullet_max = CEILING( 10*(size**3)/initial(stored_bullet.bullet_diameter), 1)
 		if(!bullet_max)
 			set_stored_bullet(null)
 			update_sprite()
 			return FALSE
-		if(generate)
-			bullet_count = bullet_max
-		rarity = stored_bullet.rarity
+		bullet_count = bullet_max
+		rarity = initial(stored_bullet.rarity)
 		return TRUE
 
 	return FALSE
@@ -177,8 +174,8 @@
 /obj/item/bulletbox/update_sprite()
 	. = ..()
 	name = initial(name)
-	if(istype(stored_bullet))
-		name = "[name] ([stored_bullet.name])"
+	if(stored_bullet)
+		name = "[name] ([initial(stored_bullet.name)])"
 
 /obj/item/bulletbox/update_icon()
 	. = ..()
@@ -189,10 +186,9 @@
 
 /obj/item/bulletbox/update_overlays()
 	. = ..()
-	if(istype(stored_bullet)) //Draw the logo on the bullet
+	if(stored_bullet) //Draw the logo on the bullet
 		if(draw_bullet_on_box)
-			var/image/I = new/image(stored_bullet.icon,stored_bullet.icon_state)
-			I.appearance = stored_bullet.appearance
+			var/image/I = new/image(initial(stored_bullet.icon),"[initial(stored_bullet.icon_state)]_1")
 			I.color = "#AAAAAA"
 			I.alpha = 200
 			var/matrix/M = matrix()
@@ -206,7 +202,7 @@
 		if((small || anchored) && bullet_count) //Draw the bullets inside.
 			var/ratio = 1 + FLOOR((bullet_count/bullet_max)*2,1)
 			if(stored_bullet)
-				var/image/I2 = new/image(icon,"[stored_bullet.bulletbox_icon_state && !ignore_custom_sprites ? stored_bullet.bulletbox_icon_state : "bullet"]_[ratio]")
+				var/image/I2 = new/image(icon,"[initial(stored_bullet.bulletbox_icon_state) && !ignore_custom_sprites ? initial(stored_bullet.bulletbox_icon_state) : "bullet"]_[ratio]")
 				add_overlay(I2)
 
 /obj/item/bulletbox/rifle_556/
@@ -221,7 +217,6 @@
 /obj/item/bulletbox/rifle_762/premium
 	stored_bullet = /obj/item/bullet_cartridge/rifle_308/nato/premium
 
-
 /obj/item/bulletbox/sniper_127/
 	stored_bullet = /obj/item/bullet_cartridge/sniper_127
 
@@ -230,7 +225,6 @@
 
 /obj/item/bulletbox/sniper_127/ap
 	stored_bullet = /obj/item/bullet_cartridge/sniper_127/ap
-
 
 /obj/item/bulletbox/shotgun_12/
 	stored_bullet = /obj/item/bullet_cartridge/shotgun_12/
@@ -244,10 +238,8 @@
 /obj/item/bulletbox/shotgun_12/slug/cleaning
 	stored_bullet = /obj/item/bullet_cartridge/shotgun_12/slug/cleaning
 
-
 /obj/item/bulletbox/rifle_762_revolver
 	stored_bullet = /obj/item/bullet_cartridge/revolver_762
-
 
 /obj/item/bulletbox/shotgun_23/
 	stored_bullet = /obj/item/bullet_cartridge/shotgun_23/
@@ -268,25 +260,20 @@
 
 /obj/item/bulletbox/small/shotgun_12
 	stored_bullet = /obj/item/bullet_cartridge/shotgun_12
-	bullet_whitelist = list(/obj/item/bullet_cartridge/shotgun_12 = TRUE)
 	icon = 'icons/obj/item/bulletbox_12.dmi'
 
 /obj/item/bulletbox/small/shotgun_12/slug
 	stored_bullet = /obj/item/bullet_cartridge/shotgun_12/slug
-	bullet_whitelist = list(/obj/item/bullet_cartridge/shotgun_12/slug = TRUE)
 	icon = 'icons/obj/item/bulletbox_12_slug.dmi'
 
 /obj/item/bulletbox/small/shotgun_12/flechette
 	stored_bullet = /obj/item/bullet_cartridge/shotgun_12/flechette
-	bullet_whitelist = list(/obj/item/bullet_cartridge/shotgun_12/flechette = TRUE)
 	icon = 'icons/obj/item/bulletbox_12_flechette.dmi'
 
 /obj/item/bulletbox/small/shotgun_12/techshot
 	stored_bullet = /obj/item/bullet_cartridge/shotgun_12/techshot
-	bullet_whitelist = list(/obj/item/bullet_cartridge/shotgun_12/techshot = TRUE)
 	icon = 'icons/obj/item/bulletbox_12_techshot.dmi'
 
 /obj/item/bulletbox/small/revolver_357
 	stored_bullet = /obj/item/bullet_cartridge/revolver_357
-	bullet_whitelist = list(/obj/item/bullet_cartridge/revolver_357 = TRUE)
 	icon = 'icons/obj/item/bulletbox_357.dmi'

--- a/code/_core/obj/item/drop_pod_remote/_supply_pod_remote.dm
+++ b/code/_core/obj/item/drop_pod_remote/_supply_pod_remote.dm
@@ -81,8 +81,8 @@
 	value = 500
 
 /obj/item/supply_remote/ammo
-	name = "drop pod remote - ammo restocker"
-	desc_extended = "A special remote designed to drop things into the battlefield. This one drops an ammo restocker."
+	name = "drop pod remote - premium ammo restocker"
+	desc_extended = "A special remote designed to drop things into the battlefield. This one drops a premium ammo restocker."
 	stored_object_types = list(
 		/obj/structure/interactive/restocker/ammo/premium
 	)

--- a/code/_core/obj/item/magazine/_magazine.dm
+++ b/code/_core/obj/item/magazine/_magazine.dm
@@ -123,6 +123,39 @@
 
 	return TRUE
 
+/obj/item/magazine/proc/can_load_magazine_path(var/mob/caller,var/obj/item/bullet_cartridge/B)
+
+	if(initial(B.is_spent))
+		caller?.to_chat(span("warning","The bullet is spent!"))
+		return FALSE
+
+	if(src.bullet_count_max <= src.get_ammo_count())
+		caller?.to_chat(span("warning","The magazine is full."))
+		return FALSE
+
+	if(initial(B.bullet_length) < bullet_length_min)
+		caller?.to_chat(span("warning","\The [B.name] is too short to be put inside \the [src.name]!"))
+		return FALSE
+
+	if(initial(B.bullet_length) > bullet_length_max)
+		caller?.to_chat(span("warning","\The [B.name] is too long to be put inside \the [src.name]!"))
+		return FALSE
+
+	if(initial(B.bullet_diameter) < bullet_diameter_min)
+		caller?.to_chat(span("warning","\The [B.name] is too narrow to be put inside \the [src.name]!"))
+		return FALSE
+
+	if(initial(B.bullet_diameter) > bullet_diameter_max)
+		caller?.to_chat(span("warning","\The [B.name] is too wide to be put inside \the [src.name]!"))
+		return FALSE
+
+	return TRUE
+
+
+
+
+
+
 /obj/item/magazine/clicked_on_by_object(var/mob/caller as mob,var/atom/object,location,control,params)
 
 	if(is_inventory(object) && length(stored_bullets))
@@ -227,6 +260,9 @@
 	icon_states = 0
 
 /obj/item/magazine/gold/can_load_magazine(var/mob/caller,var/obj/item/bullet_cartridge/B)
+	return TRUE
+
+/obj/item/magazine/gold/can_load_magazine_path(var/mob/caller,var/obj/item/bullet_cartridge/B)
 	return TRUE
 
 /obj/item/magazine/gold/click_on_object(var/mob/caller as mob,var/atom/object,location,control,params)

--- a/code/_core/obj/structure/interactive/restocker.dm
+++ b/code/_core/obj/structure/interactive/restocker.dm
@@ -59,6 +59,26 @@
 		caller.to_chat(span("notice","\The [M.name] has been restocked with [bullets_to_add] [initial(bullet_to_create.name)]."))
 		return TRUE
 
+	if(istype(object,/obj/item/bulletbox))
+		INTERACT_CHECK
+		INTERACT_CHECK_OBJECT
+		INTERACT_DELAY(5)
+		var/obj/item/bulletbox/B = object
+		var/obj/item/bullet_cartridge/bullet_to_create = B.stored_bullet
+		if(B.bullet_max == 0)
+			caller.to_chat(span("warning","The ammo box has no assigned cartridge!"))
+			return TRUE
+		var/bullets_to_add = B.bullet_max - B.bullet_count
+		if(bullets_to_add <=0)
+			caller.to_chat(span("warning","The ammo box is already full!"))
+			return TRUE
+		if(premium == B.is_surplus)
+			caller.to_chat(span("warning","It would be a bad idea to mix bullets up..."))
+			return TRUE
+		B.bullet_count += bullets_to_add
+		caller.to_chat(span("notice","The ammo box has been restocked with [bullets_to_add] [initial(bullet_to_create.name)]."))
+		return TRUE
+
 	return ..()
 
 /obj/structure/interactive/restocker/ammo/premium

--- a/code/_core/obj/structure/interactive/restocker.dm
+++ b/code/_core/obj/structure/interactive/restocker.dm
@@ -69,7 +69,7 @@
 			caller.to_chat(span("warning","The ammo box has no assigned cartridge!"))
 			return TRUE
 		var/bullets_to_add = B.bullet_max - B.bullet_count
-		if(bullets_to_add <=0)
+		if(bullets_to_add <= 0)
 			caller.to_chat(span("warning","The ammo box is already full!"))
 			return TRUE
 		if(premium == B.is_surplus)

--- a/code/_core/obj/structure/interactive/restocker.dm
+++ b/code/_core/obj/structure/interactive/restocker.dm
@@ -11,7 +11,7 @@
 	pixel_y = 10
 
 /obj/structure/interactive/restocker/ammo
-	name = "portable magazine restocker"
+	name = "portable surplus ammo restocker"
 	desc = "Warning: Does not contain literature."
 	desc_extended = "A machine that automatically fills magazines inserted into the machine with cheap surplus rounds."
 	icon = 'icons/obj/structure/vending.dmi'
@@ -19,30 +19,16 @@
 	anchored = FALSE
 	collision_flags = FLAG_COLLISION_WALL
 	var/premium = FALSE //Is this a premium ammo restocker?
+	var/currency_left = 0 //For premium ammo restockers
 
 /obj/structure/interactive/restocker/ammo/clicked_on_by_object(var/mob/caller,var/atom/object,location,control,params)
-
-	if(istype(object,/obj/item/powercell/))
-		INTERACT_CHECK
-		INTERACT_CHECK_OBJECT
-		INTERACT_DELAY(5)
-		var/obj/item/powercell/C = object
-		if(C.charge_current >= C.charge_max)
-			caller.to_chat(span("warning","You can't cram any more power into \the [C.name]!"))
-			return TRUE
-		C.charge_current = C.charge_max
-		caller.to_chat(span("notice","You swap \the [C.name] for a fully charged one."))
-		C.update_sprite()
-		return TRUE
 
 	if(istype(object,/obj/item/magazine/))
 		INTERACT_CHECK
 		INTERACT_CHECK_OBJECT
 		INTERACT_DELAY(5)
 		var/obj/item/magazine/M = object
-		var/obj/item/bullet_cartridge/bullet_to_create = M.ammo_surplus
-		if(premium && M.ammo)
-			bullet_to_create = M.ammo
+		var/obj/item/bullet_cartridge/bullet_to_create = premium || !M.ammo_surplus ? M.ammo : M.ammo_surplus
 		if(!bullet_to_create)
 			caller.to_chat(span("warning","That magazine isn't registered in our system!"))
 			return TRUE
@@ -53,28 +39,70 @@
 		if(M.next_regen > world.time)
 			caller.to_chat(span("warning","That magazine was just filled! Please wait [CEILING(DECISECONDS_TO_SECONDS(M.next_regen-world.time),1)] seconds!"))
 			return TRUE
+		if(premium)
+			var/value_per_bullet = SSbalance.stored_value[bullet_to_create]
+			if(value_per_bullet*bullets_to_add > currency_left)
+				caller.to_chat(span("warning","\The [src.name] doesn't have enough credits stored to complete this operation!"))
+				return TRUE
+			currency_left -= value_per_bullet*bullets_to_add
 		M.next_regen = world.time + SECONDS_TO_DECISECONDS(120)
 		M.stored_bullets[bullet_to_create] += bullets_to_add
 		M.update_sprite()
 		caller.to_chat(span("notice","\The [M.name] has been restocked with [bullets_to_add] [initial(bullet_to_create.name)]."))
 		return TRUE
 
+	if(istype(object,/obj/item/powercell/))
+		INTERACT_CHECK
+		INTERACT_CHECK_OBJECT
+		INTERACT_DELAY(5)
+		if(!premium)
+			caller.to_chat(span("warning","Only non-surplus ammo restockers can recharge power cells!"))
+			return TRUE
+		var/obj/item/powercell/C = object
+		var/charge_to_add = C.charge_max - C.charge_current
+		if(charge_to_add <= 0)
+			caller.to_chat(span("warning","You can't cram any more power into \the [C.name]!"))
+			return TRUE
+		if(premium)
+			if(0.001*charge_to_add > currency_left)
+				caller.to_chat(span("warning","\The [src.name] doesn't have enough credits stored to complete this operation!"))
+				return TRUE
+			currency_left -= 0.001*charge_to_add
+		C.charge_current = C.charge_max
+		caller.to_chat(span("notice","You quickly recharge \the [C.name]."))
+		C.update_sprite()
+		return TRUE
+
 	if(istype(object,/obj/item/bulletbox))
 		INTERACT_CHECK
 		INTERACT_CHECK_OBJECT
 		INTERACT_DELAY(5)
+		if(!premium)
+			caller.to_chat(span("warning","Only non-surplus ammo restockers can restock ammo boxes!"))
+			return TRUE
 		var/obj/item/bulletbox/B = object
-		var/obj/item/bullet_cartridge/bullet_to_create = B.stored_bullet
-		if(B.bullet_max == 0)
-			caller.to_chat(span("warning","The ammo box has no assigned cartridge!"))
+		var/obj/item/bullet_cartridge/bullet_to_create = initial(B.stored_bullet)
+		if(!bullet_to_create)
+			caller.to_chat(span("warning","The ammo box has no registered cartridge!"))
+			return TRUE
+		if(B.stored_bullet && B.stored_bullet != bullet_to_create)
+			caller.to_chat(span("warning","The ammo box contains a different ammo type than it's registered ammo type!"))
 			return TRUE
 		var/bullets_to_add = B.bullet_max - B.bullet_count
 		if(bullets_to_add <= 0)
-			caller.to_chat(span("warning","The ammo box is already full!"))
+			caller.to_chat(span("warning","The [B.name] is already full!"))
 			return TRUE
-		if(premium == B.is_surplus)
-			caller.to_chat(span("warning","It would be a bad idea to mix bullets up..."))
+		if(B.next_regen > world.time)
+			caller.to_chat(span("warning","That ammo box was just filled! Please wait [CEILING(DECISECONDS_TO_SECONDS(B.next_regen-world.time),1)] seconds!"))
 			return TRUE
+		if(premium)
+			var/value_per_bullet = SSbalance.stored_value[bullet_to_create]
+			if(value_per_bullet*bullets_to_add > currency_left)
+				caller.to_chat(span("warning","\The [src.name] doesn't have enough credits stored to complete this operation!"))
+				return TRUE
+			currency_left -= value_per_bullet*bullets_to_add
+
+		B.next_regen = world.time + SECONDS_TO_DECISECONDS(120)
 		B.bullet_count += bullets_to_add
 		caller.to_chat(span("notice","The ammo box has been restocked with [bullets_to_add] [initial(bullet_to_create.name)]."))
 		return TRUE
@@ -82,11 +110,20 @@
 	return ..()
 
 /obj/structure/interactive/restocker/ammo/premium
-	name = "portable premium magazine restocker"
+	name = "portable ammo restocker"
 	desc = "Warning: Does not contain premium literature."
-	desc_extended = "A machine that automatically fills magazines inserted into the machine with regular rounds. Expensive, but worth it."
+	desc_extended = "A machine that automatically fills magazines inserted into the machine with regular rounds. Also supports powercells and ammo boxes."
 	icon = 'icons/obj/structure/vending.dmi'
 	icon_state = "gear2_ammo_premium"
-	anchored = TRUE
 	collision_flags = FLAG_COLLISION_WALL
 	premium = TRUE
+	currency_left = 5000
+
+/obj/structure/interactive/restocker/ammo/premium/get_examine_list(var/mob/examiner)
+	. = ..()
+	. += div("notice","This restocker has [currency_left] credits worth of ammo left.")
+
+/obj/structure/interactive/restocker/ammo/premium/anchored
+	name = "non-portable ammo restocker"
+	anchored = TRUE
+	currency_left = 10000

--- a/code/_core/world/subsystems/cargo.dm
+++ b/code/_core/world/subsystems/cargo.dm
@@ -7,7 +7,9 @@ SUBSYSTEM_DEF(cargo)
 	var/list/cargo_id_to_type = list()
 	var/list/catalog_data = list() //What the catalog should look like (paper stuff)
 	var/list/possible_orders = list(
-
+		/obj/item/bulletbox/rifle_556/premium,
+		/obj/item/bulletbox/rifle_762/premium,
+		/obj/item/bulletbox/sniper_127/premium,
 	)
 
 /subsystem/cargo/Initialize()


### PR DESCRIPTION
# What this PR does
allows standard restockers to fill surplus ammo boxes, and premium restockers to fill non-surplus ammo boxes

# Why it should be added to the game
better ammo managemens, no more standing around a restocker for a million years refilling mags, and them emptying the mags into a box