### PR TITLE
#undef max_depth

### DIFF
--- a/code/_core/turf/simulated/floor/colored/colored_snow.dm
+++ b/code/_core/turf/simulated/floor/colored/colored_snow.dm
@@ -49,3 +49,5 @@
 
 	color = blend_colors(initial(G.color),initial(src.color),blend_mod)
 	map_color = color
+
+#undef MAX_DEPTH

--- a/code/_core/turf/simulated/hazard/water.dm
+++ b/code/_core/turf/simulated/hazard/water.dm
@@ -36,7 +36,7 @@
 
 	var/shore = FALSE
 
-/turf/simulated/liquid/water/New(var/desired_loc)
+/turf/simulated/liquid/water/New(desired_loc)
 	. = ..()
 	if(depth == 0)
 		depth = MAX_DEPTH
@@ -103,3 +103,5 @@
 
 /turf/simulated/liquid/water/desert
 	name = "oasis water"
+
+#undef MAX_DEPTH


### PR DESCRIPTION
# What this PR does
Addresses this
![image](https://github.com/BurgerLUA/burgerstation/assets/66163761/246bdcc2-4c8a-4575-ad53-3dffb0b47b43)

Should probably be a habit that you #undef thing when you don't plan on re-using them in other files
Alternatively, just define it and don't re-define it.