### PR TITLE
Prestige now sets you to Prestige Level x 5 instead of just 5

### DIFF
--- a/code/_core/datum/dialogue/npc/master.dm
+++ b/code/_core/datum/dialogue/npc/master.dm
@@ -103,13 +103,13 @@
 /dialogue/npc/master/proc/try_prestige(mob/living/advanced/player/prestiger)
 
 	var/list/valid_skills = list()
-	var/experience/skill
+	var/experience/skill_to_prestige
 
 	for(var/k in prestiger.skills)
-		skill = prestiger.skills[k]
-		if(skill.get_max_level() > skill.get_current_level())
+		skill_to_prestige = prestiger.skills[k]
+		if(skill_to_prestige.get_max_level() > skill_to_prestige.get_current_level())
 			continue
-		valid_skills += skill
+		valid_skills += skill_to_prestige
 
 	if(!length(valid_skills))
 		prestiger.to_chat(span("warning","You have no valid skills to prestige! Come back when one of your skills is above the prestige threshold."))
@@ -117,12 +117,12 @@
 
 	valid_skills += "Cancel"
 
-	var/desired_choice = input("Are you sure you wish to enter the prestige program? The chosen skill will be reset to [prestiger.prestige_count[skill.id]*5] and its max level will increase by 5.","Prestige Program","Cancel") as null|anything in valid_skills
+	var/desired_choice = input("Are you sure you wish to enter the prestige program? The chosen skill will be reset to [prestiger.prestige_count[skill_to_prestige.id]*5] and its max level will increase by 5.","Prestige Program","Cancel") as null|anything in valid_skills
 	if(!desired_choice || desired_choice == "Cancel")
 		prestiger.to_chat(span("notice","You decide not to prestige anything."))
 		return FALSE
 
-	var/experience/skill = desired_choice
-	if(skill.get_max_level() <= skill.get_current_level())
-		prestiger.prestige(skill.id)
-	return TRUE
+	skill_to_prestige = desired_choice
+	if(skill_to_prestige.get_max_level() <= skill_to_prestige.get_current_level())
+		prestiger.prestige(skill_to_prestige.id)
+		return TRUE

--- a/code/_core/datum/dialogue/npc/master.dm
+++ b/code/_core/datum/dialogue/npc/master.dm
@@ -103,12 +103,13 @@
 /dialogue/npc/master/proc/try_prestige(mob/living/advanced/player/prestiger)
 
 	var/list/valid_skills = list()
+	var/experience/skill
 
 	for(var/k in prestiger.skills)
-		var/experience/E = prestiger.skills[k]
-		if(E.get_max_level() > E.get_current_level())
+		skill = prestiger.skills[k]
+		if(skill.get_max_level() > skill.get_current_level())
 			continue
-		valid_skills += E
+		valid_skills += skill
 
 	if(!length(valid_skills))
 		prestiger.to_chat(span("warning","You have no valid skills to prestige! Come back when one of your skills is above the prestige threshold."))
@@ -116,12 +117,12 @@
 
 	valid_skills += "Cancel"
 
-	var/desired_choice = input("Are you sure you wish to enter the prestige program? The chosen skill will be reset to [prestiger.prestige_count[skill_id]*5] and its max level will increase by 5.","Prestige Program","Cancel") as null|anything in valid_skills
+	var/desired_choice = input("Are you sure you wish to enter the prestige program? The chosen skill will be reset to [prestiger.prestige_count[skill.id]*5] and its max level will increase by 5.","Prestige Program","Cancel") as null|anything in valid_skills
 	if(!desired_choice || desired_choice == "Cancel")
 		prestiger.to_chat(span("notice","You decide not to prestige anything."))
 		return FALSE
 
-	var/experience/E = desired_choice
-	if(E.get_max_level() <= E.get_current_level())
-		prestiger.prestige(E.id)
+	var/experience/skill = desired_choice
+	if(skill.get_max_level() <= skill.get_current_level())
+		prestiger.prestige(skill.id)
 	return TRUE

--- a/code/_core/datum/dialogue/npc/master.dm
+++ b/code/_core/datum/dialogue/npc/master.dm
@@ -100,28 +100,28 @@
 
 
 
-/dialogue/npc/master/proc/try_prestige(var/mob/living/advanced/player/P)
+/dialogue/npc/master/proc/try_prestige(mob/living/advanced/player/prestiger)
 
 	var/list/valid_skills = list()
 
-	for(var/k in P.skills)
-		var/experience/E = P.skills[k]
+	for(var/k in prestiger.skills)
+		var/experience/E = prestiger.skills[k]
 		if(E.get_max_level() > E.get_current_level())
 			continue
 		valid_skills += E
 
 	if(!length(valid_skills))
-		P.to_chat(span("warning","You have no valid skills to prestige! Come back when one of your skills is above the prestige threshold."))
+		prestiger.to_chat(span("warning","You have no valid skills to prestige! Come back when one of your skills is above the prestige threshold."))
 		return FALSE
 
 	valid_skills += "Cancel"
 
-	var/desired_choice = input("Are you sure you wish to enter the prestige program? The chosen skill will be reset to 5 and its max level will increase by 5.","Prestige Program","Cancel") as null|anything in valid_skills
+	var/desired_choice = input("Are you sure you wish to enter the prestige program? The chosen skill will be reset to [prestiger.prestige_count[skill_id]*5] and its max level will increase by 5.","Prestige Program","Cancel") as null|anything in valid_skills
 	if(!desired_choice || desired_choice == "Cancel")
-		P.to_chat(span("notice","You decide not to prestige anything."))
+		prestiger.to_chat(span("notice","You decide not to prestige anything."))
 		return FALSE
 
 	var/experience/E = desired_choice
 	if(E.get_max_level() <= E.get_current_level())
-		P.prestige(E.id)
+		prestiger.prestige(E.id)
 	return TRUE

--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -1,6 +1,7 @@
-/mob/living/advanced/player/
+/mob/living/advanced/player
 
-	var/unique_pid //Snowflake system that generates a md5 hash of the player on character creation.
+	///Snowflake system that generates a md5 hash of the player on character creation.
+	var/unique_pid
 
 	desc = "Seems a little smarter than most, you think."
 	desc_extended = "This is a player."
@@ -38,11 +39,14 @@
 	var/currency = 0
 	var/revenue = 0
 	var/expenses = 0
-	var/partial_tax = 0 //Taxes you couldn't pay.
+	///Taxes you couldn't pay.
+	var/partial_tax = 0
 	var/last_tax_payment = 0
 
-	var/insurance = INSURANCE_PAYOUT * 4 //How much insurance the user has. This amount is paid out in death, up to 8000 credits.
-	var/insurance_premiums = 0.05 //How much your insurance premiums are. This is taxed from your current amount each payday.
+	///How much insurance the user has. This amount is paid out in death, up to 8000 credits.
+	var/insurance = INSURANCE_PAYOUT * 4
+	///How much your insurance premiums are. This is taxed from your current amount each payday.
+	var/insurance_premiums = 0.05
 
 	var/logout_time = 0
 
@@ -81,11 +85,14 @@
 
 	var/save_id
 
-	var/ai_steps = 0 //Determining when the AI activates.
+	///Determining when the AI activates.
+	var/ai_steps = 0
 
-	var/death_ckey //The ckey belonging to this person that died. Cleared on revive.
+	///The ckey belonging to this person that died. Cleared on revive.
+	var/death_ckey
 
-	var/list/prestige_count = list() //Prestige count for each of the skills. Each count increases maximum skill by 5.
+	///Prestige count for each of the skills. Each count increases maximum skill by 5.
+	var/list/prestige_count = list()
 
 	var/list/quests = list()
 
@@ -93,12 +100,14 @@
 
 	var/list/linked_portals
 
-	var/last_autosave = 0 //The last time this player saved.
+	///The last time this player saved.
+	var/last_autosave = 0
 
 	enable_chunk_clean = FALSE
 	enable_chunk_handling = TRUE
 
-	var/is_saving = FALSE //Debug var that checks if the player is saving and freaks out if it's saving if it's qdeleted.
+	///Debug var that checks if the player is saving and freaks out if it's saving if it's qdeleted.
+	var/is_saving = FALSE
 
 	var/job/job
 	var/job_rank = 1
@@ -134,7 +143,7 @@
 			var/desired_z = CEILING(world.maxz/2,1)
 			force_move(locate(desired_x,desired_y,desired_z))
 
-/mob/living/advanced/player/get_damage_received_multiplier(var/atom/attacker,var/atom/victim,var/atom/weapon,var/atom/hit_object,var/atom/blamed,var/damagetype/DT)
+/mob/living/advanced/player/get_damage_received_multiplier(atom/attacker, atom/victim, atom/weapon, atom/hit_object, atom/blamed, damagetype/DT)
 
 	if(attacker.is_player_controlled()) //PvP is always 0.5.
 		return 0.5
@@ -149,11 +158,10 @@
 	. = ..()
 
 /mob/living/advanced/player/restore_inventory()
-
 	. = ..()
-
-	if(.)
-		client.screen += click_and_drag_icon
+	if(!.)
+		return
+	client.screen += click_and_drag_icon
 
 /mob/living/advanced/player/setup_name()
 
@@ -169,10 +177,10 @@
 	health.update_health_stats()
 	return TRUE
 
-/mob/living/advanced/player/is_safe_to_delete(var/check_loc = TRUE)
+/mob/living/advanced/player/is_safe_to_delete(check_loc = TRUE)
 	if(is_saving)
 		return FALSE
-	. = ..()
+	return ..()
 
 /mob/living/advanced/player/PreDestroy()
 
@@ -201,7 +209,7 @@
 
 	SSliving.dead_player_mobs -= src
 
-	. = ..()
+	return ..()
 
 /mob/living/advanced/player/Destroy()
 	dialogue_target = null
@@ -221,12 +229,12 @@
 
 	return TRUE
 
-/mob/living/advanced/player/proc/prestige(var/skill_id)
+/mob/living/advanced/player/proc/prestige(skill_id)
 	if(!prestige_count[skill_id])
 		prestige_count[skill_id] = 1
 	else
 		prestige_count[skill_id] += 1
-	set_skill_level(skill_id,5)
+	set_skill_level(skill_id, (prestige_count[skill_id]*5))
 	src.to_chat(span("warning","Your loyalty implant buzzes as you feel your brain tampered with... seems like you've forgot everything about [skill_id]..."))
 	src.to_chat(span("notice","You have prestiged your [skill_id]. It is now at prestige level [prestige_count[skill_id]], requiring skill level [100 + prestige_count[skill_id]*5] to prestige again."))
 	//broadcast_to_clients(span("notice","[src.real_name] prestiged their [skill_id] to level [prestige_count[skill_id]]!"))


### PR DESCRIPTION
# What this PR does
When you prestige, your level will be set to 
Prestige level * 5
instead of just
5

# Why it should be added to the game
Adding a baseline level makes it so that future prestiges don't feel shitty.
It takes a while to grind up to level 100 (and above)
It feels terrible that after all that time spent levelling, you don't really *gain* anything until you start hitting those level 101+

Giving it a baseline of prestige * 5 makes you feel like you are actually progressing.
And it's not too unreasonable balance-wise since those early levels tend to be the easiest to get (due to low exp reqs)