### PR TITLE
Pill Press Fix

### DIFF
--- a/code/_core/obj/item/crafting/pill_press.dm
+++ b/code/_core/obj/item/crafting/pill_press.dm
@@ -59,6 +59,7 @@
 		return FALSE
 
 	var/obj/item/container/edible/pill/P = new(get_turf(src))
+
 	INITIALIZE(P)
 	GENERATE(P)
 	FINALIZE(P)
@@ -66,6 +67,8 @@
 
 	I1.reagents.transfer_reagents_to(P.reagents,I1.transfer_amount, caller = caller)
 	if(I2) I2.reagents.transfer_reagents_to(P.reagents,I2.transfer_amount, caller = caller)
+
+
 
 	if(product_container)
 		product_container.add_object_to_src_inventory(caller,P,TRUE)

--- a/code/_core/obj/item/crafting/pill_press.dm
+++ b/code/_core/obj/item/crafting/pill_press.dm
@@ -63,12 +63,11 @@
 
 	INITIALIZE(P)
 	GENERATE(P)
-	FINALIZE(P)
-	caller.to_chat(span("warning","You press the button but nothing happens... Seems like the press is non-functional.")) //borgir plz fix :((((
 
 	I1.reagents.transfer_reagents_to(P.reagents,I1.transfer_amount, caller = caller)
 	if(I2) I2.reagents.transfer_reagents_to(P.reagents,I2.transfer_amount, caller = caller)
 
+	FINALIZE(P)
 
 
 

--- a/code/_core/obj/item/crafting/pill_press.dm
+++ b/code/_core/obj/item/crafting/pill_press.dm
@@ -60,6 +60,7 @@
 
 	var/obj/item/container/edible/pill/P = new(get_turf(src))
 
+
 	INITIALIZE(P)
 	GENERATE(P)
 	FINALIZE(P)
@@ -67,6 +68,7 @@
 
 	I1.reagents.transfer_reagents_to(P.reagents,I1.transfer_amount, caller = caller)
 	if(I2) I2.reagents.transfer_reagents_to(P.reagents,I2.transfer_amount, caller = caller)
+
 
 
 

--- a/code/_core/obj/item/crafting/pill_press.dm
+++ b/code/_core/obj/item/crafting/pill_press.dm
@@ -59,8 +59,6 @@
 		return FALSE
 
 	var/obj/item/container/edible/pill/P = new(get_turf(src))
-
-
 	INITIALIZE(P)
 	GENERATE(P)
 
@@ -68,8 +66,6 @@
 	if(I2) I2.reagents.transfer_reagents_to(P.reagents,I2.transfer_amount, caller = caller)
 
 	FINALIZE(P)
-
-
 
 	if(product_container)
 		product_container.add_object_to_src_inventory(caller,P,TRUE)


### PR DESCRIPTION
# What this PR does
Changes the order of code in pill_press.dm so that the pill is generated, given reagents, then checked for reagents and finalized.

# Why it should be added to the game
Us pill poppers need our fix.