### PR TITLE
Quality of life vendor items

### DIFF
--- a/code/_core/obj/item/clothing/back/storage/satchel/_satchel.dm
+++ b/code/_core/obj/item/clothing/back/storage/satchel/_satchel.dm
@@ -26,6 +26,6 @@
 	new /obj/item/weapon/melee/torch/flashlight(src)
 	new /obj/item/weapon/ranged/bullet/revolver/detective(src)
 	new /obj/item/magazine/clip/revolver/bullet_38(src)
-	new /obj/item/bullet_cartridge/revolver_38(src)
+	new /obj/item/bullet_cartridge/revolver_38{amount=6}(src)
 	new /obj/item/paper/book/controls(src)
 	. = ..()

--- a/code/_core/obj/item/paper/book/book_guides.dm
+++ b/code/_core/obj/item/paper/book/book_guides.dm
@@ -41,9 +41,9 @@
 
 /obj/item/paper/book/controls/
 	name = "Manual: A Guide to Controlling Yourself"
-	desc = "Don't ERP."
+	desc = "How do i switch hands"
 	icon_state = "book2"
-	desc_extended = "A guide on how to master self-control"
+	desc_extended = "A guide on how to master self-control. Quite literally shows you the basic Burgerstation controls when used in your hands."
 
 /obj/item/paper/book/controls/Initialize()
 	. = ..()

--- a/code/_core/obj/item/storage/emergency.dm
+++ b/code/_core/obj/item/storage/emergency.dm
@@ -1,5 +1,7 @@
 /obj/item/storage/emergency
 	name = "survival kit"
+	desc = "Where are your internals man"
+	desc_extended = "A very small box that starts with some basic medical supplies. Could save someone's life in a pinch."
 	icon = 'icons/obj/item/storage/boxes.dmi'
 	icon_state = "emergency"
 

--- a/code/_core/obj/structure/interactive/local_machine/vendor/clothes.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/clothes.dm
@@ -66,6 +66,7 @@
 		/obj/item/clothing/feet/socks/knee/striped,
 		/obj/item/clothing/feet/socks/thigh,
 		/obj/item/clothing/feet/socks/thigh/striped,
+		/obj/item/clothing/underbottom/underwear/long_johns,
 		/obj/item/clothing/underbottom/underwear/boxers,
 		/obj/item/clothing/underbottom/underwear/panty,
 		/obj/item/clothing/underbottom/underwear/thong,

--- a/code/_core/obj/structure/interactive/local_machine/vendor/clothes.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/clothes.dm
@@ -25,6 +25,7 @@
 		/obj/item/clothing/shirt/normal,
 		/obj/item/clothing/shirt/normal/striped,
 		/obj/item/clothing/shirt/normal/uniform,
+		/obj/item/clothing/shirt/normal/grey,
 		/obj/item/clothing/shirt/blouse,
 		/obj/item/clothing/shirt/blouse/frill,
 		/obj/item/clothing/shirt/blouse/uniform,
@@ -82,6 +83,7 @@
 		/obj/item/clothing/pants/normal,
 		/obj/item/clothing/pants/normal/chaps,
 		/obj/item/clothing/pants/normal/striped,
+		/obj/item/clothing/pants/normal/grey,
 		/obj/item/clothing/pants/skirt,
 		/obj/item/clothing/pants/skirt/striped,
 		/obj/item/clothing/pants/kilt,
@@ -102,9 +104,13 @@
 	icon_state = "accessories"
 	stored_types = list(
 		/obj/item/clothing/back/storage/satchel/poly,
+		/obj/item/clothing/back/storage/satchel,
 		/obj/item/clothing/back/storage/backpack/poly,
+		/obj/item/clothing/back/storage/backpack,
 		/obj/item/clothing/back/storage/dufflebag/poly,
+		/obj/item/clothing/back/storage/dufflebag/poly/grey, //the classic grey dufflebag is *mysteriously missing* from the code, might try unfucking later
 		/obj/item/clothing/belt/storage/colored,
+		/obj/item/clothing/belt/storage,
 		/obj/item/clothing/head/hat/bandana,
 		/obj/item/clothing/head/hat/skimask,
 		/obj/item/clothing/neck/cape,
@@ -123,5 +129,6 @@
 		/obj/item/clothing/head/hat/beret,
 		/obj/item/clothing/head/hat/cat,
 		/obj/item/clothing/head/hat/top,
+		/obj/item/clothing/head/hat/bowler,
 		/obj/item/clothing/head/hat/wizard
 	)

--- a/code/_core/obj/structure/interactive/local_machine/vendor/clothes.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/clothes.dm
@@ -86,8 +86,8 @@
 		/obj/item/clothing/pants/normal/grey,
 		/obj/item/clothing/pants/skirt,
 		/obj/item/clothing/pants/skirt/striped,
-		/obj/item/clothing/pants/kilt,
-
+		/obj/item/clothing/pants/skirt/grey,
+		/obj/item/clothing/pants/kilt
 	)
 
 /obj/structure/interactive/vending/clothes/shoes

--- a/code/_core/obj/structure/interactive/local_machine/vendor/essentials.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/essentials.dm
@@ -24,5 +24,7 @@
 		/obj/item/bullet_cartridge/revolver_38{amount=6},
 
 		/obj/item/storage/secure,
-		/obj/item/implanter/death_alarm
+		/obj/item/implanter/death_alarm,
+
+		/obj/item/storage/box
 	)

--- a/code/_core/obj/structure/interactive/local_machine/vendor/nanotrasen/nanotrasen_chemistry.dm
+++ b/code/_core/obj/structure/interactive/local_machine/vendor/nanotrasen/nanotrasen_chemistry.dm
@@ -40,6 +40,8 @@
 		/obj/item/container/spray,
 		/obj/item/container/syringe/hypodermic,
 		/obj/item/container/syringe/medipen,
+		/obj/item/storage/pillbottle,
+		/obj/item/storage/pillbottle/consumer,
 		/obj/item/grenade/device,
 		/obj/item/grenade/device/large,
 		/obj/item/device/timer,


### PR DESCRIPTION
# What this PR does
Adds a three very specific items (empty box, empty pill bottle + consumer variant) into the station vendors.

# Why it should be added to the game
Quality of life. Empty boxes can be found across trash piles littered in maintenance and in the area of operations (though, some may not be as lucky...) and empty pill bottles being added into chemistry vendors seems logical.