### PR TITLE
Makes the chat speed up message sending if there are too many messages queued up for a client

### DIFF
--- a/code/_core/client/life.dm
+++ b/code/_core/client/life.dm
@@ -1,12 +1,13 @@
 /client/proc/on_life()
 
 	if(length(queued_chat_messages) && queued_chat_messages[1])
-		var/list/queued_message = queued_chat_messages[1]
-		var/text = queued_message["text"]
-		var/list/targets = queued_message["output_target_list"]
-		for(var/target in targets)
-			src << output(text,target)
-		queued_chat_messages.Cut(1,2)
+		for(var/i in 1 to length(queued_chat_messages) > 20 ? 3 : 1) // If they have an excessive amount of messages, lets speed up.
+			var/list/queued_message = queued_chat_messages[1]
+			var/text = queued_message["text"]
+			var/list/targets = queued_message["output_target_list"]
+			for(var/target in targets)
+				src << output(text,target)
+			queued_chat_messages.Cut(1,2)
 
 	if(mob)
 		mob.on_life_client()


### PR DESCRIPTION
# What this PR does

Adds in a `for()` loop in the part of code that sends messages to the chat, that makes the code send 3 messages at once if the queued message list is over 20 objects

# Why it should be added to the game

Currently if you are using a weapon that shoots very rapidly you can end up waiting 20 or more seconds of just standing, waiting to view your XP tab or get any item feedback messages other than combat ones.

This is a bit unintuitive, and can lead players to think that something is lagging while it is not.

<details>
<summary>Before this PR</summary>

https://github.com/user-attachments/assets/3f356b4d-04da-4cb6-a111-bc7dd07675cc

</details>
<details>
<summary>After this PR</summary>

https://github.com/user-attachments/assets/8fda4f06-fdfe-4bd3-b814-02971eaa1ea8

</details>