### PR TITLE
Fixes typo in _tutorial.dm

### DIFF
--- a/code/_core/datum/dialogue/tutorial/_tutorial.dm
+++ b/code/_core/datum/dialogue/tutorial/_tutorial.dm
@@ -120,7 +120,7 @@
 
 	dialogue_options["get to work"] = list(
 		"In order to be a smart #1, you must be a well-equipped #2. You should first explore a little, and then head to the #3. \
-		From there, you can gear up and then head #4 to help secure the planet from #6 presence.",
+		From there, you can gear up and then head #4 to help secure the planet from #5 presence.",
 		"Corporate Mercenary",
 		"Corporate Mercenary",
 		"armory",


### PR DESCRIPTION
# What this PR does
Fixes a typo in the tutorial's "get to work" topic

Before:
![image](https://github.com/user-attachments/assets/27619621-709d-4d14-b10f-1de993e7b5fe)

After:
![image](https://github.com/user-attachments/assets/45b55d3d-7ef9-4499-8df4-4edb5a9b5af7)


# Why it should be added to the game
Makes the tutorial NPC a bit less confusing.