### PR TITLE
makes set_level() call on_level_up()

### DIFF
--- a/code/_core/datum/experience/_experience.dm
+++ b/code/_core/datum/experience/_experience.dm
@@ -57,8 +57,10 @@
 /experience/proc/set_level(var/level)
 	if(!ENABLE_XP)
 		return FALSE
+	var/old_level = get_current_level()
 	experience = level_to_xp(clamp(level,1,get_max_level()))
 	last_level = get_current_level()
+	on_level_up(old_level, last_level)
 	return experience
 
 /experience/proc/get_current_level()


### PR DESCRIPTION
# What this PR does

Makes the set_level() proc call on_level_up()

# Why it should be added to the game

Currently doing a prestige does not update your level properly, leading to jank behavior

For example, if you prestige unarmed then you will have your level set to 5, but your overall level and the individual characteristics of the level will stay as-is until you level it up to 6, then it will update as it should and tell you that your overall level decreased

Dis can lead to a bit of confusion, and its probably better to update the level immediatelly when we set it