### PR TITLE
Makes summoned bosses no longer consider nearby players as valid for blasting their music endlessly into their ears

### DIFF
--- a/code/_core/mob/living/_living.dm
+++ b/code/_core/mob/living/_living.dm
@@ -663,6 +663,9 @@
 
 	if(boss)
 		for(var/mob/living/advanced/player/P in viewers(VIEW_RANGE,src))
+			if(loyalty_tag == P.loyalty_tag)
+				continue
+
 			for(var/obj/hud/button/boss_health/B in P.buttons)
 				B.target_bosses |= src
 				B.update_stats()

--- a/code/_core/world/subsystems/boss.dm
+++ b/code/_core/world/subsystems/boss.dm
@@ -36,6 +36,9 @@ SUBSYSTEM_DEF(bosses)
 		var/ai/AI = L.ai
 		if(AI.objective_attack)
 			for(var/mob/living/advanced/player/P in viewers(L.boss_range,L))
+				if(L.loyalty_tag == P.loyalty_tag)
+					continue
+
 				CHECK_TICK(tick_usage_max,FPS_SERVER*5)
 				L.add_player_to_boss(P)
 


### PR DESCRIPTION
# What this PR does

Makes bosses not add themselfes onto nearby players `target_bosses` list, if they have the same loyalty tag as them.

# Why it should be added to the game

Please stop blasting loud music into my ears gabriel ultrakill, i know you like your music but doing it 24/7 is too much.

But genuienly, right now minion boss summons WILL force you to listen to their music for the entire round if you summon them once, on top of being able to cover up the actual REAL bosses healthbars with their own.
This is quite annoying and can mean that sometimes its better to not summon them just because they actually have negatives.