### PR TITLE
Makes it so examining your skills/attributes with more survival levels gives you tips about them

### DIFF
--- a/code/_core/datum/experience/_experience.dm
+++ b/code/_core/datum/experience/_experience.dm
@@ -40,7 +40,7 @@
 	var/current_tip = 1
 	for(var/i in 1 to length(tips))
 		if(examine_level >= examine_list[current_tip + 1])
-			completed_list[4] += span("notice", "\n[tips[current_tip]]")
+			completed_list[4] += span("notice", "\n- [tips[current_tip]]")
 		current_tip++
 
 	if(examine_level < examine_list[length(examine_list)])

--- a/code/_core/datum/experience/_experience.dm
+++ b/code/_core/datum/experience/_experience.dm
@@ -5,6 +5,12 @@
 	var/desc = "This is the base experience tracker. You shouldn't have this."
 	var/desc_extended = "Extended description for that wall of text."
 
+	/// If your survival skill is lower than this value, you will see a vague description instead of a normal extended description
+	var/skill_for_examine = 0
+	var/desc_vague = "Affects... something"
+	/// If you want, you can also optionally add in tips that show up at different levels of survival by making skill_for_examine into a list
+	var/list/tips = list()
+
 	var/experience = 0
 
 	var/chargen_min_level = 1
@@ -21,8 +27,27 @@
 
 	var/mob/living/owner
 
-/experience/get_examine_list(var/mob/examiner)
-	return list(div("examine_title","[name]"),div("examine_description","[desc]"),div("examine_description","[desc]"),div("examine_description_long",src.desc_extended))
+/experience/get_examine_list(var/mob/living/examiner)
+	var/examine_level = istype(examiner) ? examiner.get_skill_level(SKILL_SURVIVAL) : 1
+	var/list/completed_list = list(div("examine_title","[name]"),div("examine_description","[desc]"),div("examine_description","[desc]"),)
+	if(!islist(skill_for_examine))
+		var/more_xp_text = span("notice", "\n... you feel as if raising your survival skill would greatly help with evaluating this skill")
+		completed_list += div("examine_description_long", examine_level >= skill_for_examine ? src.desc_extended : "[src.desc_vague]\n[more_xp_text]")
+		return completed_list
+
+	var/list/examine_list = skill_for_examine
+	completed_list += "<div class='examine_description_long'>[examine_level >= examine_list[1] ? src.desc_extended : src.desc_vague]"
+	var/current_tip = 1
+	for(var/i in 1 to length(tips))
+		if(examine_level >= examine_list[current_tip + 1])
+			completed_list[4] += span("notice", "\n[tips[current_tip]]")
+		current_tip++
+
+	if(examine_level < examine_list[length(examine_list)])
+		completed_list[4] += span("notice", "\n... you feel as if raising your survival skill would greatly help with evaluating this skill")
+
+	completed_list[4] += "</div>"
+	return completed_list
 
 /experience/Destroy()
 	owner = null

--- a/code/_core/datum/experience/attributes.dm
+++ b/code/_core/datum/experience/attributes.dm
@@ -8,7 +8,9 @@
 /experience/attribute/strength/ //100% complete
 	name = "Strength"
 	desc = "A measure of how strong you are."
-	desc_extended = "Affects the damage of most melee weapons as well as some ranged weapons, as well as your ability to escape grabs. Can be increased by dealing damage with strength-based weapons."
+	skill_for_examine = 5
+	desc_vague = "Affects your damage in some way alongside increasing grab resistance."
+	desc_extended = "Affects the damage of most melee weapons as well as some ranged weapons, as well as your ability to escape grabs.\nCan be increased by dealing damage with strength-based weapons."
 	id = ATTRIBUTE_STRENGTH
 	flags = ATTRIBUTE_DAMAGE
 	experience_power = 1.9
@@ -17,7 +19,9 @@
 /experience/attribute/constitution/ //100% complete
 	name = "Constitution"
 	desc = "A measure of your physical well-being."
-	desc_extended = "Affects your natural resistance to the physical elements. Can be increased by taking damage from non-magical attacks."
+	skill_for_examine = 3
+	desc_vague = "Affects your resistances in some way."
+	desc_extended = "Affects your natural resistance to the physical elements.\nCan be increased by taking damage from non-magical attacks."
 	id = ATTRIBUTE_CONSTITUTION
 	flags = ATTRIBUTE_RESISTANCE
 	experience_power = 1.9
@@ -26,7 +30,9 @@
 /experience/attribute/fortitude/ //100% complete
 	name = "Fortitude"
 	desc = "A measure of how your body responds to adversity."
-	desc_extended = "Affects your natural health regeneration rate. Can be increased from regenerating your health naturally."
+	skill_for_examine = 4
+	desc_vague = "Affects your health in some way."
+	desc_extended = "Affects your natural health regeneration rate.\nCan be increased from regenerating your health naturally."
 	id = ATTRIBUTE_FORTITUDE
 	flags = ATTRIBUTE_REGEN
 	experience_power = 1.9
@@ -35,7 +41,9 @@
 /experience/attribute/vitality/ //100% complete
 	name = "Vitality"
 	desc = "A measure of your lifeforce."
-	desc_extended = "Affects your maximum health. Can be increased by leveling up strength, constitution, or fortitude."
+	skill_for_examine = 4
+	desc_vague = "Affects your health in some way."
+	desc_extended = "Affects your maximum health.\nCan be increased by leveling up strength, constitution, or fortitude."
 	id = ATTRIBUTE_VITALITY
 	flags = ATTRIBUTE_STAT | ATTRIBUTE_NO_DIFFICULTY_XP_MUL
 	experience_power = 1
@@ -50,7 +58,9 @@
 /experience/attribute/dexterity/ //100% complete
 	name = "Dexterity"
 	desc = "A measure of raw overall skill."
-	desc_extended = "Affects the damage and the attack speed of most melee weapons as well as some ranged weapons. Can be increased by dealing damage with dexterity-based weapons."
+	skill_for_examine = 5
+	desc_vague = "Affects your damage in some way."
+	desc_extended = "Affects the damage and the attack speed of most melee weapons as well as some ranged weapons.\nCan be increased by dealing damage with dexterity-based weapons."
 	id = ATTRIBUTE_DEXTERITY
 	flags = ATTRIBUTE_DAMAGE
 	experience_power = 1.9
@@ -59,7 +69,9 @@
 /experience/attribute/agility //0% complete
 	name = "Agility"
 	desc = "A measure of how fast your body can move."
-	desc_extended = "Affects the maximum speed at which you can move, as well as the strength of slowdown negation. Can be increased by sprinting."
+	skill_for_examine = 2
+	desc_vague = "Affects your speed in some way."
+	desc_extended = "Affects the maximum speed at which you can move, as well as the strength of slowdown negation.\nCan be increased by sprinting."
 	id = ATTRIBUTE_AGILITY
 	flags = ATTRIBUTE_RESISTANCE
 	experience_power = 1.9
@@ -68,7 +80,9 @@
 /experience/attribute/resilience/ //100% complete
 	name = "Resilience"
 	desc = "A measure of how well your body reacts to physical exhertion."
-	desc_extended = "Affects your natural stamina regeneration rate. Can be increased from regenerating your stamina naturally."
+	skill_for_examine = 2
+	desc_vague = "Affects your stamina in some way."
+	desc_extended = "Affects your natural stamina regeneration rate.\nCan be increased from regenerating your stamina naturally."
 	id = ATTRIBUTE_RESILIENCE
 	flags = ATTRIBUTE_REGEN
 	experience_power = 1.9
@@ -77,7 +91,9 @@
 /experience/attribute/endurance/ //100% complete
 	name = "Endurance"
 	desc = "A measure of how long your body can last."
-	desc_extended = "Affects your maximum stamina. Can be increased by leveling up dexterity, agility, or resilience."
+	skill_for_examine = 3
+	desc_vague = "Affects your stamina in some way."
+	desc_extended = "Affects your maximum stamina.\nCan be increased by leveling up dexterity, agility, or resilience."
 	id = ATTRIBUTE_ENDURANCE
 	flags = ATTRIBUTE_STAT | ATTRIBUTE_NO_DIFFICULTY_XP_MUL
 	experience_power = 1
@@ -93,7 +109,9 @@
 /experience/attribute/intelligence/ //100% complete
 	name = "Intelligence"
 	desc = "A measure of how quickly and accurately you can apply knowledge."
-	desc_extended = "Affects the damage of most magical spells, powers, and abilities. Can be increased by dealing damage with spell-based weapons."
+	skill_for_examine = 6
+	desc_vague = "Affects your damage in some way."
+	desc_extended = "Affects the damage of most magical spells, powers, and abilities.\nCan be increased by dealing damage with spell-based weapons."
 	id = ATTRIBUTE_INTELLIGENCE
 	flags = ATTRIBUTE_DAMAGE
 	experience_power = 1.9
@@ -102,7 +120,9 @@
 /experience/attribute/willpower/ //100% complete
 	name = "Willpower"
 	desc = "A measure of how well you can control your mind."
-	desc_extended = "Affects your natural mana regeneration rate. Can be increased by regenerating your mana naturally."
+	skill_for_examine = 6
+	desc_vague = "Affects your mana in some way."
+	desc_extended = "Affects your natural mana regeneration rate.\nCan be increased by regenerating your mana naturally."
 	id = ATTRIBUTE_WILLPOWER
 	flags = ATTRIBUTE_REGEN
 	experience_power = 1.9
@@ -111,7 +131,9 @@
 /experience/attribute/soul //100% complete
 	name = "Soul"
 	desc = "A measure of how strong your spirtual being is."
-	desc_extended = "Affects your natural resistances to the arcane. Can be increased by taking damage from magical attacks."
+	skill_for_examine = 7
+	desc_vague = "Affects your resistances in some way."
+	desc_extended = "Affects your natural resistances to the arcane.\nCan be increased by taking damage from magical attacks."
 	id = ATTRIBUTE_SOUL
 	flags = ATTRIBUTE_RESISTANCE
 	experience_power = 1.9
@@ -120,7 +142,9 @@
 /experience/attribute/wisdom/ //100% complete
 	name = "Wisdom"
 	desc = "A measure of how much knowledge you have."
-	desc_extended = "Affects your maximum mana. Can be increased by leveling up willpower, soul, and intelligence."
+	skill_for_examine = 7
+	desc_vague = "Affects your mana in some way."
+	desc_extended = "Affects your maximum mana.\nCan be increased by leveling up willpower, soul, and intelligence."
 	id = ATTRIBUTE_WISDOM
 	flags = ATTRIBUTE_STAT | ATTRIBUTE_NO_DIFFICULTY_XP_MUL
 	experience_power = 1

--- a/code/_core/datum/experience/skills.dm
+++ b/code/_core/datum/experience/skills.dm
@@ -11,6 +11,8 @@
 	name = "Melee"
 	id = SKILL_MELEE
 	desc = "Be the ninja weeb space samurai you always wanted to be."
+	skill_for_examine = 2
+	desc_vague = "Affects your damage in some way."
 	desc_extended = "Your skill in performing attacks with melee weapons. Affects the damage of swords, clubs, and even a toolbox."
 	experience_power = 1.6
 	experience_multiplier = 43
@@ -20,6 +22,8 @@
 	name = "Prayer"
 	id = SKILL_PRAYER
 	desc = "Have a little faith in space jesus."
+	skill_for_examine = 6
+	desc_vague = "Affects some of your spells in some way."
 	desc_extended = "Your skill in praying to the gods. Affects the strength, speed, and success rate of casting prayer-based spells and abilities."
 	experience_power = 1.6
 	experience_multiplier = 43
@@ -30,7 +34,14 @@
 	//Level 100 is 1 million xp.
 	name = "Block"
 	id = SKILL_BLOCK
-	desc = "Your skill in blocking attacks with a weapon or a shield. Affects the chance of a successful block of swords, bucklers, or even your fists."
+	desc = "YOU SHALL NOT PASS!"
+	skill_for_examine = list(3, 7, 8)
+	desc_vague = "Affects your blocking in some way."
+	desc_extended = "Your skill in blocking attacks with a weapon or a shield. Affects the chance of a successful block of swords, bucklers, or even your fists."
+	tips = list(
+		"When blocking, if an enemy attacks you in 1 second you will parry them, avoiding all damage and possibly stunning the opponent.",
+		"Perfect parrying whilst avoiding all damage, does not grant you blocking expirience.",
+	)
 	experience_power = 1.6
 	experience_multiplier = 28
 
@@ -39,7 +50,10 @@
 	//Level 100 is 1 million xp.
 	name = "Armor"
 	id = SKILL_ARMOR
-	desc = "Your skill in blocking attacks with armor. Affects which armor you can wear."
+	desc = "As close to immortality as you can get."
+	skill_for_examine = 3
+	desc_vague = "Affects your armor in some way."
+	desc_extended = "Your skill in blocking attacks with armor. Affects which armor you can wear."
 	experience_power = 1.6
 	experience_multiplier = 28
 
@@ -51,6 +65,8 @@
 	name = "Ranged"
 	id = SKILL_RANGED
 	desc = "Space Texas Sharpshooter."
+	skill_for_examine = 4
+	desc_vague = "Affects your damage in some way."
 	desc_extended = "Your skill in performing attacks with ranged weapons. Affects the damage and accuracy of bows, crossbows, guns, and throwing objects."
 	experience_power = 1.6
 	experience_multiplier = 43
@@ -59,7 +75,10 @@
 	//Each time you dodge = 1 xp
 	name = "Evasion"
 	id = SKILL_EVASION
-	desc = "Your skill in dodging incoming attacks. Affects the chance of a successful dodge from melee weapons, ranged weapons, and magic."
+	desc = "\"Turns on bullet time and dodges your every attack\""
+	skill_for_examine = 4
+	desc_vague = "Affects your dodging in some way."
+	desc_extended = "Your skill in dodging incoming attacks. Affects the chance of a successful dodge from melee weapons, ranged weapons, and magic."
 	experience_power = 1.6
 	experience_multiplier = 2.6
 
@@ -69,6 +88,8 @@
 	name = "Unarmed"
 	id = SKILL_UNARMED
 	desc = "Kapooooooooooooooooooooooooooooooooooooooooooooooow."
+	skill_for_examine = 2
+	desc_vague = "Affects your damage in some way."
 	desc_extended = "Your skill in performing attacks with your fists. Affects the damage of your bare hands, brass knuckles, or power fists."
 	experience_power = 1.6
 	experience_multiplier = 28
@@ -87,6 +108,8 @@
 	name = "Magic"
 	id = SKILL_MAGIC
 	desc = "Not to be confused with sorcery."
+	skill_for_examine = 6
+	desc_vague = "Affects your spells in some way."
 	desc_extended = "Your skill in casting support and defensive spells like summoning magic."
 	experience_power = 1.6
 	experience_multiplier = 43
@@ -95,14 +118,22 @@
 	name = "Summoning"
 	id = SKILL_SUMMONING
 	desc = "Not to be confused with prayer."
+	skill_for_examine = list(5, 10)
 	desc_extended = "Your skill in casting summoning related magic such as summon skeleton."
 	experience_power = 1.6
 	experience_multiplier = 43
+
+/experience/skill/summoning/get_examine_list(var/mob/living/examiner)
+	if(tips == initial(tips)) // Since this tip has an updating value, we need to put it here
+		tips += "Your summoning slots are expanded as you level up summoning, currently you can maintain [floor(max(1,1 + get_power(0,1,2)*3))] creatures"
+	return ..()
 
 /experience/skill/medicine/ //ATTRIBUTE_WILLPOWER
 	name = "Medicine"
 	id = SKILL_MEDICINE
 	desc = "Surgery isn't in, yet!"
+	skill_for_examine = 5
+	desc_vague = "Affects your treatment in some way."
 	desc_extended = "Your skill in treating yourself and others with actual medicine. Affects the treatment times and strength of bandages."
 	experience_power = 1.6
 	experience_multiplier = 28
@@ -112,7 +143,9 @@
 	//Level 100 is 1 million xp.
 	name = "Precision"
 	id = SKILL_PRECISION
-	desc = "There is actually a difference between precision and accurancy."
+	desc = "There is actually a difference between precision and accuracy."
+	skill_for_examine = 7
+	desc_vague = "Affects your damage in some way."
 	desc_extended = "Your skill in striking vital points of creatures and humanoids. Affects the rate in which critical hits occur."
 	experience_power = 1.6
 	experience_multiplier = 28

--- a/code/_core/datum/experience/skills.dm
+++ b/code/_core/datum/experience/skills.dm
@@ -14,11 +14,11 @@
 	skill_for_examine = list(2, 15)
 	desc_vague = "Affects your damage in some way."
 	desc_extended = "Your skill in performing attacks with melee weapons. Affects the damage of swords, clubs, and even a toolbox."
-	experience_power = 1.6
-	experience_multiplier = 43
 	tips = list(
 		"You can perform a strong swing by holding alt and clicking on an enemy.\nThis deals 2 times the damage but requires a wind-up and consumes some stamina.",
 	)
+	experience_power = 1.6
+	experience_multiplier = 43
 
 /experience/skill/prayer/ //ATTRIBUTE_CONSTITUTION
 	//Each point of damage dealt or healed = 1xp
@@ -56,7 +56,7 @@
 	desc = "As close to immortality as you can get."
 	skill_for_examine = 3
 	desc_vague = "Affects your armor in some way."
-	desc_extended = "Your skill in blocking attacks with armor. Affects which armor you can wear."
+	desc_extended = "Your skill in blocking attacks with your armor."
 	experience_power = 1.6
 	experience_multiplier = 28
 

--- a/code/_core/datum/experience/skills.dm
+++ b/code/_core/datum/experience/skills.dm
@@ -11,11 +11,14 @@
 	name = "Melee"
 	id = SKILL_MELEE
 	desc = "Be the ninja weeb space samurai you always wanted to be."
-	skill_for_examine = 2
+	skill_for_examine = list(2, 15)
 	desc_vague = "Affects your damage in some way."
 	desc_extended = "Your skill in performing attacks with melee weapons. Affects the damage of swords, clubs, and even a toolbox."
 	experience_power = 1.6
 	experience_multiplier = 43
+	tips = list(
+		"You can perform a strong swing by holding alt and clicking on an enemy.\nThis deals 2 times the damage but requires a wind-up and consumes some stamina.",
+	)
 
 /experience/skill/prayer/ //ATTRIBUTE_CONSTITUTION
 	//Each point of damage dealt or healed = 1xp
@@ -118,7 +121,7 @@
 	name = "Summoning"
 	id = SKILL_SUMMONING
 	desc = "Not to be confused with prayer."
-	skill_for_examine = list(5, 10)
+	skill_for_examine = list(5, 30)
 	desc_extended = "Your skill in casting summoning related magic such as summon skeleton."
 	experience_power = 1.6
 	experience_multiplier = 43

--- a/code/_core/datum/experience/skills.dm
+++ b/code/_core/datum/experience/skills.dm
@@ -124,8 +124,7 @@
 	experience_multiplier = 43
 
 /experience/skill/summoning/get_examine_list(var/mob/living/examiner)
-	if(tips == initial(tips)) // Since this tip has an updating value, we need to put it here
-		tips += "Your summoning slots are expanded as you level up summoning, currently you can maintain [floor(max(1,1 + get_power(0,1,2)*3))] creatures"
+	tips = list("Your summoning slots are expanded as you level up summoning, currently you can maintain [floor(max(1,1 + get_power(0,1,2)*3))] creatures")
 	return ..()
 
 /experience/skill/medicine/ //ATTRIBUTE_WILLPOWER

--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -115,44 +115,6 @@
 
 	expiration_time = SECONDS_TO_DECISECONDS(180)
 
-/mob/living/advanced/player/get_examine_list(var/mob/living/examiner)
-	var/list/species_to_names = list(
-		"human" = "human",
-		"reptile_advanced" = prob(10) ? "spine dragger" : "lizard",
-		"cyborg" = prob(10) ? "tin can": "cyborg",
-		"diona" = "dionae",
-		"moth" = prob(10) ? "moff" : "moth"
-	)
-
-	. = list(
-		div("examine_title", src.name),
-		div("center bold","Level [level] [species_to_names[species]]"),
-		div("examine_description_long", src.desc_extended)
-	)
-
-	var/activity_text = get_activity_text()
-	if(activity_text)
-		. += activity_text
-
-	var/examine_level = istype(examiner) ? examiner.get_skill_level(SKILL_SURVIVAL) : 1
-	if(examine_level >= 50)
-		var/weakness_name = ""
-		var/weakness = 0
-		for(var/i in overall_clothing_defense_rating)
-			if(i == "items" || i < -10000)
-				continue
-
-			if(weakness > overall_clothing_defense_rating[i])
-				weakness_name = i
-				weakness = overall_clothing_defense_rating[i]
-
-		if(weakness < 0)
-			. += div("notice", "[src.name]'s weakness seems to be [weakness_name] damage.")
-
-	var/damage_description = get_damage_description(examiner)
-	if(damage_description)
-		. += damage_description
-
 /mob/living/advanced/player/Finalize()
 	. = ..()
 	setup_difficulty()

--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -115,7 +115,43 @@
 
 	expiration_time = SECONDS_TO_DECISECONDS(180)
 
+/mob/living/advanced/player/get_examine_list(var/mob/living/examiner)
+	var/list/species_to_names = list(
+		"human" = "human",
+		"reptile_advanced" = prob(10) ? "spine dragger" : "lizard",
+		"cyborg" = prob(10) ? "tin can": "cyborg",
+		"diona" = "dionae",
+		"moth" = prob(10) ? "moff" : "moth"
+	)
 
+	. = list(
+		div("examine_title", src.name),
+		div("center bold","Level [level] [species_to_names[species]]"),
+		div("examine_description_long", src.desc_extended)
+	)
+
+	var/activity_text = get_activity_text()
+	if(activity_text)
+		. += activity_text
+
+	var/examine_level = istype(examiner) ? examiner.get_skill_level(SKILL_SURVIVAL) : 1
+	if(examine_level >= 50)
+		var/weakness_name = ""
+		var/weakness = 0
+		for(var/i in overall_clothing_defense_rating)
+			if(i == "items" || i < -10000)
+				continue
+
+			if(weakness > overall_clothing_defense_rating[i])
+				weakness_name = i
+				weakness = overall_clothing_defense_rating[i]
+
+		if(weakness < 0)
+			. += div("notice", "[src.name]'s weakness seems to be [weakness_name] damage.")
+
+	var/damage_description = get_damage_description(examiner)
+	if(damage_description)
+		. += damage_description
 
 /mob/living/advanced/player/Finalize()
 	. = ..()


### PR DESCRIPTION
# What this PR does

Makes it so skills/attributes by default have very vague descriptions, with your survival expirience increasing the detail in them.
Also adds in a framework for adding tips to skills/attributes, also locked behind survival expirience of course

The survival skill required to unlock the description of a skill/attribute was chosen by taking how early you level it up, and only 2 of the same number exist in the same file.

Currently the tips are:
SKILL_MELEE
- level 15: "You can perform a strong swing by holding alt and clicking on an enemy.\n
This deals 2 times the damage but requires a wind-up and consumes some stamina."

SKILL_BLOCK
- level 7: "When blocking, if an enemy attacks you in 1 second you will parry them, avoiding all damage and possibly stunning the opponent."
- level 8: "Perfect parrying whilst avoiding all damage, does not grant you blocking expirience."

SKILL_SUMMONING
- level 30: "Your summoning slots are expanded as you level up summoning, currently you can maintain [math] creatures"

# Why it should be added to the game

Currently survival does not do what it states on the tin, and i think it would be neat adding in tips to skills that tell you about obscure things