### PR TITLE
Fixes ore's icon and value

### DIFF
--- a/code/_core/obj/item/material/_material.dm
+++ b/code/_core/obj/item/material/_material.dm
@@ -50,6 +50,7 @@
 /obj/item/material/get_base_value()
 	var/material/M = SSmaterials.all_materials[material_id]
 	. = M.value_per_unit * material_multiplier
+	. *= amount
 	. = CEILING(.,1)
 
 /obj/item/material/Finalize()

--- a/code/_core/obj/item/material/ore.dm
+++ b/code/_core/obj/item/material/ore.dm
@@ -7,7 +7,7 @@
 	icon_state = null
 
 	amount_max = 50
-	amount_max_icon = 6
+	amount_max_icon = 3
 
 	material_multiplier = 1
 
@@ -21,7 +21,7 @@
 	else
 		name = "[deunderscore(M.name)] ore"
 		color = "#FFFFFF"
-		icon_state = "[M.icon_state_ore]_[min(amount_max_icon,amount)]"
+		icon_state = "[M.icon_state_ore]_[min(amount_max_icon,CEILING(amount/15,1))]"
 	return ..()
 
 /*


### PR DESCRIPTION
# What this PR does
Fixes the icon of ores, and fixes the value of stacks of ores

# Why it should be added to the game
Makes ores much easier to use, and worth more.