### PR TITLE
Makes the round-end revival no longer reset your nutrition to default

### DIFF
--- a/code/_core/mob/living/life.dm
+++ b/code/_core/mob/living/life.dm
@@ -135,13 +135,14 @@
 	update_eyes()
 	return TRUE
 
-/mob/living/proc/rejuvenate()
+/mob/living/proc/rejuvenate(var/reset_nutrition = TRUE)
 	blood_volume = blood_volume_max
 	if(reagents) reagents.remove_all_reagents()
-	nutrition_normal = initial(nutrition_normal)
-	nutrition_fast = initial(nutrition_fast)
-	nutrition_quality = initial(nutrition_quality)
-	hydration = max(hydration,initial(hydration))
+	if(reset_nutrition)
+		nutrition_normal = initial(nutrition_normal)
+		nutrition_fast = initial(nutrition_fast)
+		nutrition_quality = initial(nutrition_quality)
+		hydration = max(hydration,initial(hydration))
 	intoxication = initial(intoxication)
 	on_fire = initial(on_fire)
 	fire_stacks = initial(fire_stacks)
@@ -159,8 +160,8 @@
 	stamina_regen_buffer = 0
 	return TRUE
 
-/mob/living/proc/resurrect()
-	return rejuvenate() && revive()
+/mob/living/proc/resurrect(var/reset_nutrition = TRUE)
+	return rejuvenate(reset_nutrition) && revive()
 
 /mob/living/proc/pre_death()
 	brute_regen_buffer = max(brute_regen_buffer,0)

--- a/code/_core/world/_world.dm
+++ b/code/_core/world/_world.dm
@@ -223,7 +223,7 @@ var/global/world_state = STATE_STARTING
 			continue
 		if(!L.ckey_last)
 			continue
-		L.resurrect()
+		L.resurrect(FALSE)
 		L.add_status_effect(IMMORTAL)
 		CHECK_TICK_HARD
 


### PR DESCRIPTION
# What this PR does

Makes it so the round-end revive no longer resets your nutrition to the default

# Why it should be added to the game

It feels like a punishment to have your 180% nutritional health to be reset into 50% at round-end
Also the round-end revive makes eating/drinking a lot less important, personally i just like having to deal with them.
