### PR TITLE
Makes creatures that exit a soulgem inherit its soul power, stopping infinite enchantment recharge + sprite fixes

### DIFF
--- a/code/_core/obj/item/soulgems/_soulgem.dm
+++ b/code/_core/obj/item/soulgems/_soulgem.dm
@@ -70,9 +70,10 @@
 		var/turf/T = is_turf(hit_atom) ? hit_atom : get_turf(hit_atom)
 		if(T)
 			var/mob/living/mob_to_spawn = stored_soul_path
+			mob_to_spawn = new mob_to_spawn(T)
+			mob_to_spawn.soul_size = total_charge
 			src.total_charge = 0
 			src.stored_soul_path = null
-			mob_to_spawn = new mob_to_spawn(T)
 			INITIALIZE(mob_to_spawn)
 			GENERATE(mob_to_spawn)
 			master.add_minion(mob_to_spawn)
@@ -87,6 +88,7 @@
 				if(is_advanced(master))
 					var/mob/living/advanced/A = master
 					src.quick_equip(A,ignore_worn=TRUE,ignore_dynamic=TRUE,silent=TRUE)
+			update_sprite()
 
 /obj/item/soulgem/update_sprite()
 	. = ..()
@@ -152,7 +154,7 @@
 		if(total_charge != 0)
 			caller.to_chat(span("warning","You need an empty soul gem in order to capture souls!"))
 			return TRUE
-		if(L.soul_size > src.total_capacity)
+		if(initial(L.soul_size) > src.total_capacity)
 			caller.to_chat(span("warning","This soul is too large to be contained in \the [src.name]!"))
 			return TRUE
 		total_charge = min(L.soul_size,total_capacity)


### PR DESCRIPTION
# What this PR does

- Soulgems when having power sucked out of a soul will now properly set that soulpower to the mob, making it so you can no longer repair your enchantment, pop out a gabriel out of your gem, pop them back in and repeat so endlessly

- Fixes throwing out unbreaking gems not properly updating their sprites to be empty

# Why it should be added to the game

1'st point feels like a bug or a weird mechanic, assuming its a bug and squashing it
2'nd annoys me personally, and is 100% a bug