### PR TITLE
Makes NPC's seek out players again

### DIFF
--- a/code/_core/datum/ai/ai_life.dm
+++ b/code/_core/datum/ai/ai_life.dm
@@ -37,7 +37,7 @@
 		owner.resist()
 		return TRUE
 
-	if(aggression > 0 && can_attack && objective_attack)
+	if(aggression > 0 && can_attack)
 		if(!master_ai) //Find objectives only if you don't belong to a master.
 			objective_ticks += tick_rate
 			var/actual_objective_delay = get_objective_delay()

--- a/code/_core/datum/ai/ai_life.dm
+++ b/code/_core/datum/ai/ai_life.dm
@@ -50,7 +50,7 @@
 					queue_find_new_objectives = TRUE
 					frustration_attack = 0
 
-		if(owner.attack_next <= world.time)
+		if(objective_attack && (owner.attack_next <= world.time))
 			handle_attacking()
 
 		if(queue_find_new_objectives)


### PR DESCRIPTION
# What this PR does

Moves one var check back to where it was, specifically for if the AI has an objective to attack currently

This fixes random elimination squads/enemies chilling until you attack them

# Why it should be added to the game

In the same commit that burger made AI's run away at round end, they tried to make the code a bit neater by pushing back `can_attack` and `objective_attack` 1 proc backwards.
That in fact made every AI unable to find players, ever, as long as they were not attacked.
