### PR TITLE
Makes chemical infused bandages much better

### DIFF
--- a/code/_core/obj/item/container/medicine/_medicine.dm
+++ b/code/_core/obj/item/container/medicine/_medicine.dm
@@ -38,15 +38,15 @@
 
 /obj/item/container/healing/Generate(var/desired_loc)
 	. = ..()
-	if(reagents) reagents.volume_max = amount*reagent_max_per_amount
+	if(reagents) reagents.volume_max = amount * reagent_max_per_amount
 
 /obj/item/container/healing/Finalize(var/desired_loc)
 	. = ..()
-	if(reagents) reagents.volume_max = amount*reagent_max_per_amount //Safety
+	if(reagents) reagents.volume_max = amount * reagent_max_per_amount //Safety
 
-/obj/item/container/healing/add_item_count(var/amount_to_add,var/bypass_checks = FALSE)
+/obj/item/container/healing/add_item_count(var/amount_to_add, var/bypass_checks = FALSE)
 	. = ..()
-	if(reagents) reagents.volume_max = max(1,amount)*reagent_max_per_amount
+	if(reagents && amount) reagents.volume_max = amount * reagent_max_per_amount
 
 /obj/item/container/healing/quick(var/mob/caller,var/atom/object,location,params)
 
@@ -100,7 +100,6 @@
 	if(reagents)
 		var/transfer_amount = min(reagent_max_per_amount, reagents.volume_current)
 		reagents.transfer_reagents_to(A.reagents, transfer_amount, caller = caller)
-		reagents.volume_max = amount * reagent_max_per_amount
 
 	if(caller == A.loc)
 		caller.visible_message(span("notice","\The [caller.name] bandages their [A.name]."),span("notice","You bandage your [A.name]."))

--- a/code/_core/obj/item/container/medicine/_medicine.dm
+++ b/code/_core/obj/item/container/medicine/_medicine.dm
@@ -98,9 +98,9 @@
 				P.add_skill_xp(SKILL_MEDICINE,CEILING(experience_gain,1))
 
 	if(reagents)
-		var/reagent_transfer = CEILING((1/amount_max)*reagents.volume_current, 1)
-		reagents.transfer_reagents_to(A.reagents,reagent_transfer, caller = caller)
-		reagents.volume_max = amount*10
+		var/transfer_amount = min(reagent_max_per_amount, reagents.volume_current)
+		reagents.transfer_reagents_to(A.reagents, transfer_amount, caller = caller)
+		reagents.volume_max = amount * reagent_max_per_amount
 
 	if(caller == A.loc)
 		caller.visible_message(span("notice","\The [caller.name] bandages their [A.name]."),span("notice","You bandage your [A.name]."))

--- a/code/_core/obj/item/container/medicine/medicine_subtypes.dm
+++ b/code/_core/obj/item/container/medicine/medicine_subtypes.dm
@@ -8,6 +8,7 @@
 	heal_brute_percent = 0
 	heal_bleeding = TRUE
 	amount_max = 10
+	reagent_max_per_amount = 10
 
 	value = 30
 
@@ -16,7 +17,6 @@
 /obj/item/container/healing/bandage/Generate()
 	. = ..()
 	amount = 3
-	reagents.volume_max = amount*10
 
 /obj/item/container/healing/bandage/advanced
 	name = "infused bandages (styptic powder)"
@@ -27,7 +27,7 @@
 
 /obj/item/container/healing/bandage/advanced/Generate()
 	. = ..()
-	reagents.add_reagent(/reagent/medicine/styptic_powder,reagents.volume_max)
+	reagents.add_reagent(/reagent/medicine/styptic_powder, reagents.volume_max)
 
 /obj/item/container/healing/ointment
 	name = "ointment"
@@ -53,7 +53,7 @@
 
 /obj/item/container/healing/ointment/advanced/Generate()
 	. = ..()
-	reagents.add_reagent(/reagent/medicine/silver_sulfadiazine,reagents.volume_max)
+	reagents.add_reagent(/reagent/medicine/silver_sulfadiazine, reagents.volume_max)
 
 /obj/item/container/healing/trauma_kit
 	name = "trauma kit"
@@ -87,7 +87,7 @@
 
 /obj/item/container/healing/trauma_kit/advanced/Generate()
 	. = ..()
-	reagents.add_reagent(/reagent/medicine/styptic_powder,reagents.volume_max)
+	reagents.add_reagent(/reagent/medicine/styptic_powder, reagents.volume_max)
 
 /obj/item/container/healing/nanopaste
 	name = "nanopaste"
@@ -188,7 +188,7 @@
 
 /obj/item/container/healing/burn_kit/advanced/Generate()
 	. = ..()
-	reagents.add_reagent(/reagent/medicine/silver_sulfadiazine,reagents.volume_max)
+	reagents.add_reagent(/reagent/medicine/silver_sulfadiazine, reagents.volume_max)
 
 /obj/item/container/healing/cable
 	name = "cable"
@@ -229,7 +229,7 @@
 
 /obj/item/container/healing/patch/brute/Generate()
 	. = ..()
-	reagents.add_reagent(/reagent/medicine/styptic_powder,reagents.volume_max)
+	reagents.add_reagent(/reagent/medicine/styptic_powder, reagents.volume_max)
 
 /obj/item/container/healing/patch/burn
 	name = "burn patch (Silver Sulfadiazine)"
@@ -239,7 +239,7 @@
 
 /obj/item/container/healing/patch/burn/Generate()
 	. = ..()
-	reagents.add_reagent(/reagent/medicine/silver_sulfadiazine,reagents.volume_max)
+	reagents.add_reagent(/reagent/medicine/silver_sulfadiazine, reagents.volume_max)
 
 /obj/item/container/healing/patch/synthflesh
 	name = "regeneration patch (Synthflesh)"
@@ -249,7 +249,7 @@
 
 /obj/item/container/healing/patch/synthflesh/Generate()
 	. = ..()
-	reagents.add_reagent(/reagent/medicine/synthflesh,reagents.volume_max)
+	reagents.add_reagent(/reagent/medicine/synthflesh, reagents.volume_max)
 
 /obj/item/container/healing/gauze
 	name = "gauze"


### PR DESCRIPTION
# What this PR does

- Medicine(bandages) no longer use a scaling formula, they now always inject the highest amount of chemicals (per 1 bandage) possible
- Medicine no longer is hard-coded to set its max reagent amount to item_amount*10 upon treatment, its now correctly set to the max amount a medical item allows, squashing the bug that made treatment kits overflow at a certain point
- Bandages now properly can only hold 10 units of chemical per bandage

# Why it should be added to the game

1. Its annoying working with an endlessly changing amount of transferred chemicals, hell it even leads to your treatment kits having 2 times the allowed amount of chemicals.
When you infuse them with 150u at 10 amount, and then treat yourself till the last one remains, at that point you will have 30u per that one treatment kit despite them having 15u max

2. Bug squish make squish sounds

3. Hee hee, bug go \*splat\*