### PR TITLE
Makes boss pinpointers no longer show dead bosses

### DIFF
--- a/code/_core/obj/item/pinpointer.dm
+++ b/code/_core/obj/item/pinpointer.dm
@@ -361,8 +361,12 @@
 	var/list/possible_bosses = list()
 
 	for(var/k in SSbosses.tracked_bosses)
-		var/atom/A = k
+		var/mob/living/A = k
 		if(!can_track(A))
+			continue
+		if(!is_living(A))
+			continue
+		if(A.health.health_current < 0)
 			continue
 		var/name_mod = "[A.name] ([dir2text(get_dir_advanced(caller,A))], [get_dist_advanced(src,A)]m)"
 		possible_bosses[name_mod] = A


### PR DESCRIPTION
# What this PR does

The boss pinpointers now check for the health of the boss, if its less than 0 its excluded from da list

# Why it should be added to the game

Its annoying tuning your pinpointer onto a boss only to find its dead, this should somewhat solve that
