### PR TITLE
Fixes a very old bug with players being examined

### DIFF
--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -116,9 +116,10 @@
 	expiration_time = SECONDS_TO_DECISECONDS(180)
 
 /mob/living/advanced/player/get_examine_list(var/mob/living/examiner)
+	var/species/owner_species = SPECIES(species)
 	. = list(
 		div("examine_title", src.name),
-		div("center bold","Level [level] [SPECIES(species)]"),
+		div("center bold","Level [level] [owner_species.name]"),
 		div("examine_description_long", src.desc_extended)
 	)
 

--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -116,17 +116,9 @@
 	expiration_time = SECONDS_TO_DECISECONDS(180)
 
 /mob/living/advanced/player/get_examine_list(var/mob/living/examiner)
-	var/list/species_to_names = list(
-		"human" = "human",
-		"reptile_advanced" = prob(10) ? "spine dragger" : "lizard",
-		"cyborg" = prob(10) ? "tin can": "cyborg",
-		"diona" = "dionae",
-		"moth" = prob(10) ? "moff" : "moth"
-	)
-
 	. = list(
 		div("examine_title", src.name),
-		div("center bold","Level [level] [species_to_names[species]]"),
+		div("center bold","Level [level] [SPECIES(species)]"),
 		div("examine_description_long", src.desc_extended)
 	)
 

--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -115,6 +115,44 @@
 
 	expiration_time = SECONDS_TO_DECISECONDS(180)
 
+/mob/living/advanced/player/get_examine_list(var/mob/living/examiner)
+	var/list/species_to_names = list(
+		"human" = "human",
+		"reptile_advanced" = prob(10) ? "spine dragger" : "lizard",
+		"cyborg" = prob(10) ? "tin can": "cyborg",
+		"diona" = "dionae",
+		"moth" = prob(10) ? "moff" : "moth"
+	)
+
+	. = list(
+		div("examine_title", src.name),
+		div("center bold","Level [level] [species_to_names[species]]"),
+		div("examine_description_long", src.desc_extended)
+	)
+
+	var/activity_text = get_activity_text()
+	if(activity_text)
+		. += activity_text
+
+	var/examine_level = istype(examiner) ? examiner.get_skill_level(SKILL_SURVIVAL) : 1
+	if(examine_level >= 50)
+		var/weakness_name = ""
+		var/weakness = 0
+		for(var/i in overall_clothing_defense_rating)
+			if(i == "items" || overall_clothing_defense_rating[i] < -10000) // If someone is THAT weak, they are lying for attention
+				continue
+
+			if(weakness > overall_clothing_defense_rating[i])
+				weakness_name = i
+				weakness = overall_clothing_defense_rating[i]
+
+		if(weakness < 0)
+			. += div("notice", "[src.name]'s weakness seems to be [weakness_name] damage.")
+
+	var/damage_description = get_damage_description(examiner)
+	if(damage_description)
+		. += damage_description
+
 /mob/living/advanced/player/Finalize()
 	. = ..()
 	setup_difficulty()

--- a/code/_core/mob/living/advanced/player/_player.dm
+++ b/code/_core/mob/living/advanced/player/_player.dm
@@ -134,21 +134,6 @@
 	if(activity_text)
 		. += activity_text
 
-	var/examine_level = istype(examiner) ? examiner.get_skill_level(SKILL_SURVIVAL) : 1
-	if(examine_level >= 50)
-		var/weakness_name = ""
-		var/weakness = 0
-		for(var/i in overall_clothing_defense_rating)
-			if(i == "items" || overall_clothing_defense_rating[i] < -10000) // If someone is THAT weak, they are lying for attention
-				continue
-
-			if(weakness > overall_clothing_defense_rating[i])
-				weakness_name = i
-				weakness = overall_clothing_defense_rating[i]
-
-		if(weakness < 0)
-			. += div("notice", "[src.name]'s weakness seems to be [weakness_name] damage.")
-
 	var/damage_description = get_damage_description(examiner)
 	if(damage_description)
 		. += damage_description


### PR DESCRIPTION
# What this PR does

- Fixes the very old bug of players having the description "Level X Your name here.", This is due to the starting name of humanoids being "Your name here.". Now it instead displays the species in that place
- Examining a human no longer even tries to try and take their picture, it never worked, they are too "special"

Before
![Before](https://github.com/user-attachments/assets/c4cda58d-b057-4acd-9365-81f66d9ab8aa)

After
![After](https://github.com/user-attachments/assets/408b8ca8-f2ea-4f99-9357-04690f9dcf55)

# Why it should be added to the game

Its a bit weird to have the "Level 55 your name here" examine text show up