### PR TITLE
Changes the mirror sheld to be legendary rarity, and the iron great shield to be mythical

### DIFF
--- a/code/_core/obj/item/weapon/melee/shields.dm
+++ b/code/_core/obj/item/weapon/melee/shields.dm
@@ -122,7 +122,7 @@
 
 	value = 900
 
-	rarity = RARITY_RARE
+	rarity = RARITY_MYTHICAL
 
 /obj/item/weapon/melee/shield/heartstone
 	name = "heartstone shield"
@@ -209,7 +209,7 @@
 
 	value = 1200
 
-	rarity = RARITY_RARE
+	rarity = RARITY_LEGENDARY
 
 /obj/item/weapon/melee/shield/redstar
 	name = "slavic redstar shield"


### PR DESCRIPTION
# What this PR does

In the title, changes the great mirror shield to be legendary whilst the great iron shield is changed to be mythical

# Why it should be added to the game

I think these rarities are better for those because:
- The great iron shield has 100% unarmed and melee blocking, as the one of 2 shields that give complete 100% blocking to resistances (the second one being the projectile shield)
- The great mirror shield whilst not having 100% blocking, gets 90% in 3 categories, one of whom being magic that dosent have a 100% block alternative. At level 125 that makes the shield have 100% block in projectiles, melee AND magic