### PR TITLE
Fixes being able to use ghost commands as a living player, possibly deleting every single item you own and allowing a lot of exploits.

### DIFF
--- a/code/_core/client/verbs/view.dm
+++ b/code/_core/client/verbs/view.dm
@@ -166,7 +166,7 @@
 		if(!(permissions & FLAG_PERMISSION_MODERATOR) && !(permissions & FLAG_PERMISSION_ADMIN))
 			to_chat(span("warning", "You cannot use ghost commands as a living player."))
 			return FALSE
-		to_chat(span("warning", "Skipping living player safety check due to admin privileges."))
+		to_chat(span("notice", "ADMIN: Skipping living player safety check."))
 
 	var/area/A = coverted_choice[choice]
 

--- a/code/_core/client/verbs/view.dm
+++ b/code/_core/client/verbs/view.dm
@@ -6,12 +6,18 @@
 
 	var/mob/choice = input("Who would you like to jump to?","Jump to Mob") as null|mob in SSliving.all_mobs_with_clients
 	if(!choice || choice == mob)
-		to_chat(span("warning","Invalid mob."))
+		to_chat(span("warning","Invalid mob selected."))
 		return FALSE
+
+	if(is_living(mob))
+		if(!(permissions & FLAG_PERMISSION_MODERATOR) && !(permissions & FLAG_PERMISSION_ADMIN))
+			to_chat(span("warning", "You cannot use ghost commands as a living player."))
+			return FALSE
+		to_chat(span("notice", "ADMIN: Skipping living player safety check."))
 
 	var/turf/T = get_turf(choice)
 	if(!T)
-		to_chat(span("warning","Invalid turf."))
+		to_chat(span("warning","Target is in an Invalid turf."))
 		return FALSE
 
 	mob.force_move(T)
@@ -28,8 +34,14 @@
 
 	var/mob/choice = input("Who would you like to jump to?","Jump to Mob") as null|mob in SSliving.all_mobs
 	if(!choice || choice == mob)
-		to_chat(span("warning","Invalid mob."))
+		to_chat(span("warning","Invalid mob selected."))
 		return FALSE
+
+	if(is_living(mob))
+		if(!(permissions & FLAG_PERMISSION_MODERATOR) && !(permissions & FLAG_PERMISSION_ADMIN))
+			to_chat(span("warning", "You cannot use ghost commands as a living player."))
+			return FALSE
+		to_chat(span("notice", "ADMIN: Skipping living player safety check."))
 
 	var/turf/T = get_turf(choice)
 	if(!T)
@@ -42,8 +54,7 @@
 	if(is_living(mob))
 		log_admin("[mob.get_debug_name()] jumped to [choice.get_debug_name()]'s location.")
 
-/client/verb/jump_to_client()
-
+/client/verb/jump_to_client() // Admin-only
 	set name = "Jump to Client"
 	set category = "View"
 
@@ -85,16 +96,16 @@
 
 	var/mob/choice = input("Who would you like to orbit?","Orbit Mob") as null|mob in SSliving.all_mobs_with_clients
 	if(!choice || choice == mob)
-		to_chat(span("warning","Invalid mob."))
+		to_chat(span("warning","Invalid mob selected."))
+		return FALSE
+
+	if(is_living(mob))
+		to_chat(span("warning","Cannot orbit as a living mob."))
 		return FALSE
 
 	var/turf/T = get_turf(choice)
 	if(!T)
 		to_chat(span("warning","Invalid turf."))
-		return FALSE
-
-	if(is_living(mob))
-		to_chat(span("warning","Cannot orbit as a living mob."))
 		return FALSE
 
 	if(mob.observing)
@@ -118,13 +129,13 @@
 		to_chat(span("warning","Invalid mob."))
 		return FALSE
 
+	if(is_living(mob))
+		to_chat(span("warning","Cannot orbit as a living mob."))
+		return FALSE
+
 	var/turf/T = get_turf(choice)
 	if(!T)
 		to_chat(span("warning","Invalid turf."))
-		return FALSE
-
-	if(is_living(mob))
-		to_chat(span("warning","Cannot orbit as a living mob."))
 		return FALSE
 
 	if(mob.observing)
@@ -150,6 +161,12 @@
 	if(!choice)
 		to_chat(span("warning","Invalid area."))
 		return FALSE
+
+	if(is_living(mob))
+		if(!(permissions & FLAG_PERMISSION_MODERATOR) && !(permissions & FLAG_PERMISSION_ADMIN))
+			to_chat(span("warning", "You cannot use ghost commands as a living player."))
+			return FALSE
+		to_chat(span("warning", "Skipping living player safety check due to admin privileges."))
 
 	var/area/A = coverted_choice[choice]
 


### PR DESCRIPTION
# What this PR does

Title
Ghost commands now have checks to see if the mob that has them should actually have them
Being an admin skips those checks, so this has no change to admins

# Why it should be added to the game

Apparently using them can delete players items, or at least that was shown in testing.
Also allows a LOT of exploits, so better not