### PR TITLE
Major doctor bag rebalance

### DIFF
--- a/code/_core/obj/item/doctor_bag.dm
+++ b/code/_core/obj/item/doctor_bag.dm
@@ -2,13 +2,14 @@
 	name = "doctor's bag"
 	desc = "HOLD STILL!"
 	desc_extended = "A highly advanced set of surgery tools and general medical equipment to make you excel at your duties of being a doctor. \
-	Heals the target's limb by a fixed amount based on your medical skill. Treatment power and time is also based on your medical skill, and is improved if the target is laying down. Cannot be used to self-treat. Using this while taking the Medical Doctor job can earn you credits if you treat your fellow man."
+	Heals the target's limb by a fixed amount based on your medical skill. Treatment power and time is also based on your medical skill, and is improved if the target is laying down. Cannot be used to self-treat. Using this while taking the Medical Doctor job can earn you credits if you treat your fellow man. Clicking on it will let you change healing modes."
 	icon = 'icons/obj/item/doctor_bag.dmi'
 	icon_state = "inventory"
 
 	value = 1 //generated
 
 	var/organic = TRUE
+	var/heal_all_limbs = FALSE
 
 	var/heal_brute = 20 //At 100 medicine.
 	var/heal_burn = 20 //At 100 medicine.
@@ -23,16 +24,29 @@
 
 	size = SIZE_3
 
+	quality_max = 190
 	quality = 100
 
-	uses_until_condition_fall = 1000 //1000 uses.
+	uses_until_condition_fall = 1
 
 /obj/item/doctor_bag/get_base_value()
 	. = 100 + ((heal_burn+heal_brute)*10 + (heal_brute_percent + heal_burn_percent)*40) * (SECONDS_TO_DECISECONDS(6) / (base_delay + added_delay*0.5)) * 1.5
 	. = FLOOR(.,100)
 
-/obj/item/doctor_bag/click_on_object(var/mob/caller,var/atom/object,location,control,params)
+/obj/item/doctor_bag/click_self(var/mob/caller,location,control,params)
 
+	INTERACT_CHECK
+	INTERACT_DELAY(1)
+
+	heal_all_limbs = !heal_all_limbs
+	if(heal_all_limbs)
+		caller.to_chat(span("notice","You decide to heal injuries of others more broadly, at the cost of healing power."))
+	else
+		caller.to_chat(span("warning","You decide to focus on healing a singular limb."))
+
+	return TRUE
+
+/obj/item/doctor_bag/click_on_object(var/mob/caller,var/atom/object,location,control,params)
 
 	if(is_living(object) && is_living(caller))
 
@@ -122,6 +136,10 @@
 
 	if(!target_as_living.horizontal) //Not horizontal penalty.
 		medicine_power *= 0.5
+
+	if(heal_all_limbs && is_living(A.loc)) // If we are on the second healing mode, heal more broadly at a severe penalty.
+		A = A.loc
+		medicine_power *= 0.25
 
 	medicine_power = max(medicine_power,0.1)
 


### PR DESCRIPTION
# What this PR does

- First off, doctor bags were bugged, so they would not lose quality, ever, even after 1000 uses because their maximum integrity was not set above normal integrity.
This fixes that and makes it so frogging the doctor bag has a chance to reach the mystical above 190 quality to get an infinite doctor bag, just like before.

- Secondly, makes doctor bags lose 1 quality per use. This is a VERY steep increase in quality cost (ignoring that it was infinite before), but its able to be justified with the next thingy.

- NEW HEALING MODE: BROAD. It lets you heal all of the limbs on a player at once, but your healing is 4 times less efficient
- (This is to adress the issue of very good medicine skill being able to heal 1K+ HP on a limb, whilst the player as a whole has 600 health, and EVERY limb on that person is damaged a little bit)

# Why it should be added to the game

With infinite integrity, bugs bad.

With the 1 quality per use drop, it actually becomes something you have to watch out for and encurages to get gambling for the mystical 190+ integrity medical doctor bag.

Its very annoying to switch to someones 11 limbs all individually, especially with then possibly running around cancelling your do_after bar several times.
Making it heal all limb damage at once is very handy, can get a bigger healing penalty if 4 times is not enough.