### PR TITLE
tiny 516 caller fix

### DIFF
--- a/code/_core/obj/item/herald_mirror.dm
+++ b/code/_core/obj/item/herald_mirror.dm
@@ -47,8 +47,6 @@
 
 /obj/item/herald_mirror/proc/can_teleport(var/mob/living/advanced/A)
 
-	var/mob/caller = A //reeee shitcode
-
 	INTERACT_CHECK_NO_DELAY(src)
 
 	if(!linked_destination)

--- a/code/_core/obj/item/herald_mirror.dm
+++ b/code/_core/obj/item/herald_mirror.dm
@@ -47,7 +47,8 @@
 
 /obj/item/herald_mirror/proc/can_teleport(var/mob/living/advanced/A)
 
-	INTERACT_CHECK_NO_DELAY(src)
+	if(!can_caller_interact_with(A, delay_checks = FALSE)) // This is INTERACT_CHECK_NO_DELAY(x) but 516 friendly
+		return FALSE
 
 	if(!linked_destination)
 		A.to_chat(span("warning","Something went wrong... tell Burger on discord."))

--- a/code/_core/world/subsystems/client.dm
+++ b/code/_core/world/subsystems/client.dm
@@ -67,14 +67,14 @@ SUBSYSTEM_DEF(client)
 		if(!data || !length(data))
 			queued_automatics -= k
 			continue
-		var/mob/caller = data[1]
+		var/mob/mob = data[1]
 		var/list/params = data[2]
 		var/damage_multiplier = data[3]
 		var/max_bursts_to_use = data[4]
 		var/shoot_delay_to_use = data[5]
 		if(R.next_shoot_time > world.time)
 			continue
-		if(!R.handle_automatic(caller,params,damage_multiplier,max_bursts_to_use,shoot_delay_to_use))
+		if(!R.handle_automatic(mob,params,damage_multiplier,max_bursts_to_use,shoot_delay_to_use))
 			var/real_burst_delay = (R.burst_delay ? R.burst_delay : R.shoot_delay*R.current_bursts*1.25) - R.shoot_delay*R.current_bursts
 			R.next_shoot_time = max(R.next_shoot_time,world.time + real_burst_delay)
 			R.current_bursts = 1


### PR DESCRIPTION
# What this PR does

Should make the game compile on latest stable beta(516.1657)

Now the newest version probably has a lot of broken stuff, but nothing IMMEDIATELLY noticable, this fixes the only compile errors
namelly on 516 caller and callee are vars used by byond, so we shouldn't use it anymore.

Why 434 files can still use it without breaking is byond me.

# Why it should be added to the game

Version breaking bugs bad