### PR TITLE
Adds quality_max to a bunch of items, rework of quality additions + frog fix

### DIFF
--- a/code/_core/obj/item/_item_quality.dm
+++ b/code/_core/obj/item/_item_quality.dm
@@ -10,18 +10,24 @@
 		return 0
 	return FLOOR(clamp( (100 - quality) / (100/5),0,5 ),1)
 
-/obj/item/proc/adjust_quality(var/quality_to_add=0)
-
+/obj/item/proc/can_adjust_quality(var/quality_to_check = quality_max)
 	if(quality == -1)
 		return FALSE
 
-	if(quality >= quality_max) //Cannot add or remove quality.
-		return TRUE
+	if(quality >= quality_to_check) //Cannot add or remove quality.
+		return FALSE
+
+	return TRUE
+
+/obj/item/proc/adjust_quality(var/quality_to_add = 0, var/maximum_quality = quality_max)
+	. = can_adjust_quality(maximum_quality)
+	if(!.)
+		return .
 
 	var/original_quality = quality
 	var/original_damage_num = get_damage_icon_number()
 
-	quality = FLOOR(quality + quality_to_add,0.01)
+	quality = min(FLOOR(quality + quality_to_add,0.01), maximum_quality)
 
 	if(original_quality > 0 && quality <= 0)
 		visible_message(span("danger","\The [src.name] breaks!"))

--- a/code/_core/obj/item/_item_quality.dm
+++ b/code/_core/obj/item/_item_quality.dm
@@ -20,14 +20,13 @@
 	return TRUE
 
 /obj/item/proc/adjust_quality(var/quality_to_add = 0, var/maximum_quality = quality_max)
-	. = can_adjust_quality(maximum_quality)
-	if(!.)
-		return .
+	if(!can_adjust_quality(maximum_quality))
+		return FALSE
 
 	var/original_quality = quality
 	var/original_damage_num = get_damage_icon_number()
 
-	quality = min(FLOOR(quality + quality_to_add,0.01), maximum_quality)
+	quality = clamp(FLOOR(quality + quality_to_add, 0.01), 0, maximum_quality)
 
 	if(original_quality > 0 && quality <= 0)
 		visible_message(span("danger","\The [src.name] breaks!"))

--- a/code/_core/obj/item/clothing/_clothing.dm
+++ b/code/_core/obj/item/clothing/_clothing.dm
@@ -43,6 +43,7 @@
 	var/list/mob_values_mul
 
 	quality = 100
+	quality_max = 175
 
 	inventory_sounds = list(
 		'sound/effects/inventory/rustle1.ogg',

--- a/code/_core/obj/item/clothing/additional.dm
+++ b/code/_core/obj/item/clothing/additional.dm
@@ -31,8 +31,7 @@
 
 /obj/item/clothing/proc/sync_additional_clothing()
 
-	for(var/k in additional_clothing_stored)
-		var/obj/item/C = k
+	for(var/obj/item/C as anything in additional_clothing_stored)
 		C.color = color
 		C.quality = quality
 		C.polymorphs = polymorphs
@@ -41,3 +40,9 @@
 		C.update_sprite()
 
 	return TRUE
+
+/obj/item/clothing/adjust_quality(var/quality_to_add = 0)
+	. = ..()
+	if(.)
+		for(var/obj/item/C as anything in additional_clothing_stored)
+			C.quality = quality

--- a/code/_core/obj/item/corrupting_frog.dm
+++ b/code/_core/obj/item/corrupting_frog.dm
@@ -23,7 +23,7 @@
 		activator.to_chat(span("warning","You can't temper \the [I.name] with \the [src.name]! Try tempering the main part of this clothing set."))
 		return FALSE
 
-	if(I.quality <= -1)
+	if(!I.can_adjust_quality())
 		activator.to_chat(span("warning","\The [src.name] cannot be used with \the [I.name]!"))
 		return FALSE
 
@@ -39,13 +39,8 @@
 
 	can_use = FALSE
 
+	I.adjust_quality(rand(1, I.quality_max) - I.quality, 200)
 	play_sound('sound/weapons/magic/zap_large.ogg',get_turf(src))
-
-	I.adjust_quality(rand(1, 200) - I.quality)
-
-	if(is_clothing(I))
-		var/obj/item/clothing/C = I
-		C.sync_additional_clothing()
 
 	qdel(src)
 

--- a/code/_core/obj/item/supportgem.dm
+++ b/code/_core/obj/item/supportgem.dm
@@ -12,6 +12,7 @@
 	var/power_per_quality = 0 //Above 100.
 
 	quality = 100
+	quality_max = 175
 
 	color = "#FFFFFF"
 	var/color_2 = "#FFFFFF"

--- a/code/_core/obj/item/tempering/_tempering.dm
+++ b/code/_core/obj/item/tempering/_tempering.dm
@@ -7,7 +7,6 @@
 
 	var/increase = 5
 	var/minimum = 100
-	var/maximum = 125
 
 	var/uses_left = 1 //How many times can this object be used to improve something? Set to -1 for infinity.
 

--- a/code/_core/obj/item/tempering/tempering_luck.dm
+++ b/code/_core/obj/item/tempering/tempering_luck.dm
@@ -6,7 +6,7 @@
 
 	increase = 1
 	minimum = 50
-	maximum = 100
+	var/maximum = 100
 
 	temper_whitelist = /obj/item/
 

--- a/code/_core/obj/item/tempering/tempering_quality.dm
+++ b/code/_core/obj/item/tempering/tempering_quality.dm
@@ -16,11 +16,11 @@
 
 /obj/item/tempering/quality/can_temper(var/mob/activator,var/obj/item/I)
 
-	if(I.quality <= -1)
+	if(!I.can_adjust_quality())
 		activator.to_chat(span("warning","\The [I.name] cannot be improved!"))
 		return FALSE
 
-	if(I.quality >= maximum)
+	if(I.quality >= I.quality_max)
 		activator.to_chat(span("warning","\The [I.name] cannot be improved any further!"))
 		return FALSE
 
@@ -28,25 +28,34 @@
 
 /obj/item/tempering/quality/get_examine_list(var/mob/examiner)
 	. = ..()
-	. += span("notice","Increases the quality of [item_type_name] by [increase]%, up to [maximum]%, with a minimum of [minimum]%.")
+	. += span("notice","Increases the quality of [item_type_name] by [increase]%, with a minimum of [minimum]%.")
 
-/obj/item/tempering/quality/on_temper(var/mob/activator,var/obj/item/I)
-	I.quality = clamp(I.quality + increase,minimum,maximum)
-	. = ..()
+/obj/item/tempering/quality/on_temper(var/mob/activator, var/obj/item/I)
+	I.adjust_quality((I.quality + increase) > minimum ? increase : minimum - I.quality)
+	return ..()
 
 /obj/item/tempering/quality/general
-	name = "advanced repair kit"
+	name = "advanced repair kitaaaa"
 	desc = "Your gear is your life. Take care of it!"
 	desc_extended = "A collection of scrap, tools, and generally useful materials that can help you maintain the condition any sort of item."
 	icon_state = "repair_kit"
 
 	increase = 25
 	minimum = 50
-	maximum = 100
 
 	temper_whitelist = /obj/item
 
 	value = 400
+
+/obj/item/tempering/quality/general/can_temper(var/mob/activator,var/obj/item/I)
+	if(I.quality >= 100) // We exist only to repair
+		return FALSE
+
+	return ..()
+
+/obj/item/tempering/quality/general/on_temper(var/mob/activator,var/obj/item/I)
+	. = ..()
+	I.quality = min(I.quality, 100)
 
 /obj/item/tempering/quality/melee
 	name = "chef's whetstone"
@@ -56,9 +65,8 @@
 
 	increase = 5
 	minimum = 100
-	maximum = 175
 
-	temper_whitelist = list(/obj/item/weapon/melee,/obj/item/weapon/unarmed,/obj/item/weapon/ranged/thrown)
+	temper_whitelist = list(/obj/item/weapon/melee, /obj/item/weapon/unarmed, /obj/item/weapon/ranged/thrown)
 
 	value = 500
 
@@ -70,7 +78,6 @@
 
 	increase = 5
 	minimum = 100
-	maximum = 175
 
 	temper_whitelist = /obj/item/clothing
 	value = 750
@@ -85,9 +92,13 @@
 
 	increase = 5
 	minimum = 100
-	maximum = 175
 
-	temper_whitelist = list(/obj/item/weapon/ranged/bullet,/obj/item/weapon/ranged/energy, /obj/item/weapon/ranged/reagent_ammo/,/obj/item/weapon/ranged/bow)
+	temper_whitelist = list(
+		/obj/item/weapon/ranged/bullet,
+		/obj/item/weapon/ranged/energy,
+		/obj/item/weapon/ranged/reagent_ammo/,
+		/obj/item/weapon/ranged/bow,
+	)
 	value = 1000
 
 /obj/item/tempering/quality/ranged/energy
@@ -98,7 +109,6 @@
 
 	increase = 10
 	minimum = 100
-	maximum = 175
 
 	temper_whitelist = /obj/item/weapon/ranged/energy
 	value = 3000
@@ -111,13 +121,12 @@
 
 	increase = 5
 	minimum = 100
-	maximum = 175
 
-	temper_whitelist = list(/obj/item/weapon/ranged/spellgem,/obj/item/weapon/ranged/wand,/obj/item/supportgem)
+	temper_whitelist = list(/obj/item/weapon/ranged/spellgem, /obj/item/weapon/ranged/wand, /obj/item/supportgem)
 	value = 1250
 
 /obj/item/tempering/quality/ranged/magic/on_temper(var/mob/activator,var/obj/item/I)
 	. = ..()
-	if(istype(I,/obj/item/supportgem))
+	if(istype(I, /obj/item/supportgem))
 		var/obj/item/supportgem/SG = I
 		SG.update_support_stats()

--- a/code/_core/obj/item/tempering/tempering_quality.dm
+++ b/code/_core/obj/item/tempering/tempering_quality.dm
@@ -27,11 +27,14 @@
 	. += span("notice","Increases the quality of [item_type_name] by [increase]%, with a minimum of [minimum]%.")
 
 /obj/item/tempering/quality/on_temper(var/mob/activator, var/obj/item/I)
-	I.adjust_quality((I.quality + increase) > minimum ? increase : minimum - I.quality)
+	if((I.quality + increase) > minimum)
+		I.adjust_quality(increase)
+	else
+		I.adjust_quality(minimum - I.quality)
 	return ..()
 
 /obj/item/tempering/quality/general
-	name = "advanced repair kitaaaa"
+	name = "advanced repair kit"
 	desc = "Your gear is your life. Take care of it!"
 	desc_extended = "A collection of scrap, tools, and generally useful materials that can help you maintain the condition any sort of item."
 	icon_state = "repair_kit"
@@ -92,7 +95,7 @@
 	temper_whitelist = list(
 		/obj/item/weapon/ranged/bullet,
 		/obj/item/weapon/ranged/energy,
-		/obj/item/weapon/ranged/reagent_ammo/,
+		/obj/item/weapon/ranged/reagent_ammo,
 		/obj/item/weapon/ranged/bow,
 	)
 	value = 1000

--- a/code/_core/obj/item/tempering/tempering_quality.dm
+++ b/code/_core/obj/item/tempering/tempering_quality.dm
@@ -20,10 +20,6 @@
 		activator.to_chat(span("warning","\The [I.name] cannot be improved!"))
 		return FALSE
 
-	if(I.quality >= I.quality_max)
-		activator.to_chat(span("warning","\The [I.name] cannot be improved any further!"))
-		return FALSE
-
 	return ..()
 
 /obj/item/tempering/quality/get_examine_list(var/mob/examiner)

--- a/code/_core/obj/item/weapon/melee/_melee.dm
+++ b/code/_core/obj/item/weapon/melee/_melee.dm
@@ -1,6 +1,7 @@
 obj/item/weapon/melee
 	name = "Melee Weapon"
 	desc = "A melee weapon"
+	quality_max = 175
 
 	drop_sound = 'sound/items/drop/sword.ogg'
 

--- a/code/_core/obj/item/weapon/ranged/bow/_bow.dm
+++ b/code/_core/obj/item/weapon/ranged/bow/_bow.dm
@@ -3,6 +3,7 @@
 	icon_state = "inventory"
 
 	requires_bullets = TRUE
+	quality_max = 175
 
 	shoot_sounds = list(
 		'sound/weapons/ranged/bow/fire.ogg'

--- a/code/_core/obj/item/weapon/ranged/bullet/_bullet.dm
+++ b/code/_core/obj/item/weapon/ranged/bullet/_bullet.dm
@@ -29,6 +29,7 @@
 	var/bullet_diameter_max = -1
 
 	uses_until_condition_fall = 50 // ~5000 rounds.
+	quality_max = 175
 
 	use_iff_tag = TRUE
 

--- a/code/_core/obj/item/weapon/ranged/laser/_laser.dm
+++ b/code/_core/obj/item/weapon/ranged/laser/_laser.dm
@@ -16,6 +16,7 @@
 	use_iff_tag = TRUE
 
 	damage_mod = 1
+	quality_max = 175
 
 	var/charge_icon_state_count = 0
 	var/old_charge_icon_state

--- a/code/_core/obj/item/weapon/ranged/reagent_ammo/_reagent_ammo.dm
+++ b/code/_core/obj/item/weapon/ranged/reagent_ammo/_reagent_ammo.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/ranged/reagent_ammo/
 	var/reagent_volume_per_shot = 0 //reagents from reagent container to remove per-shot.
+	quality_max = 175
 
 /obj/item/weapon/ranged/reagent_ammo/get_ammo_count()
 

--- a/code/_core/obj/item/weapon/ranged/spellgem/_spellgem.dm
+++ b/code/_core/obj/item/weapon/ranged/spellgem/_spellgem.dm
@@ -9,6 +9,7 @@
 	var/color_3 = null //Outline
 
 	var/spread_per_shot = 5 //Angle to add per shot.
+	quality_max = 175
 
 	automatic = TRUE
 

--- a/code/_core/obj/item/weapon/ranged/thrown/_thrown.dm
+++ b/code/_core/obj/item/weapon/ranged/thrown/_thrown.dm
@@ -7,6 +7,7 @@
 
 	amount = 1
 	amount_max = 1
+	quality_max = 175
 
 	projectile = /obj/projectile/thrown //Always needs to be thrown
 	shoot_sounds = list('sound/effects/fwoosh.ogg')

--- a/code/_core/obj/item/weapon/ranged/wand/_wand.dm
+++ b/code/_core/obj/item/weapon/ranged/wand/_wand.dm
@@ -10,6 +10,7 @@
 	var/list/obj/item/supportgem/socketed_supportgems = list()
 
 	automatic = TRUE
+	quality_max = 175
 
 	var/wand_damage_multiplier = 1
 

--- a/code/_core/obj/item/weapon/unarmed/_unarmed.dm
+++ b/code/_core/obj/item/weapon/unarmed/_unarmed.dm
@@ -1,6 +1,7 @@
 obj/item/weapon/unarmed
 	name = "Unarmed Weapon"
 	desc = "An unarmed weapon"
+	quality_max = 175
 
 	drop_sound = 'sound/items/drop/sword.ogg'
 


### PR DESCRIPTION
# What this PR does

So as it turns out, basically nothing has any sort of maximum quality defined on it, this PR makes every single item that before could be tempered have maximum quality equivilant to the level of tempering you could do.

Also now `adjust_quality` has a check for maximum quality, you can manually override it as a second variable if you wish to do something funky (corrupting frog)

This PR also introduces a new proc named `can_adjust_quality` that allows you to check if a given item can have its quality affected before trying to adjust its quality, for when you want to not waste your precious frog

# Why it should be added to the game

Quality removing or adding items should be much more consistent, fixes up frog and makes the procs safer to interact with