### PR TITLE
Fixes max tempering

### DIFF
--- a/code/_core/obj/item/tempering/tempering_quality.dm
+++ b/code/_core/obj/item/tempering/tempering_quality.dm
@@ -73,7 +73,7 @@
 
 	increase = 5
 	minimum = 100
-	increase_maximum = 1
+	increase_maximum = 5
 
 	temper_whitelist = list(/obj/item/weapon/melee, /obj/item/weapon/unarmed, /obj/item/weapon/ranged/thrown)
 
@@ -87,7 +87,7 @@
 
 	increase = 5
 	minimum = 100
-	increase_maximum = 1
+	increase_maximum = 5
 
 	temper_whitelist = /obj/item/clothing
 	value = 750
@@ -102,7 +102,7 @@
 
 	increase = 5
 	minimum = 100
-	increase_maximum = 1
+	increase_maximum = 5
 
 	temper_whitelist = list(
 		/obj/item/weapon/ranged/bullet,
@@ -119,7 +119,7 @@
 
 	increase = 10
 	minimum = 100
-	increase_maximum = 1
+	increase_maximum = 5
 
 	temper_whitelist = /obj/item/weapon/ranged/energy
 	value = 3000
@@ -132,7 +132,7 @@
 
 	increase = 5
 	minimum = 100
-	increase_maximum = 1
+	increase_maximum = 5
 
 	temper_whitelist = list(/obj/item/weapon/ranged/spellgem, /obj/item/weapon/ranged/wand, /obj/item/supportgem)
 	value = 1250


### PR DESCRIPTION
# What this PR does
So this just changes a few numbers around in the code because condition increasing items are supposed to increase everything by 5 percent. However max condition only increased by 1, thus causing a conflict where max condition is increased by 1, but normal conditions and everything increases by 5 without adding to the max.

# Why it should be added to the game

Max condition and general condition increasing doesnt make sense. the normal condition increases by 5 however max increases only by 1. With this math and how objects can be upgraded to 200 percent now. If you were to upgrade an item at 100 percent condition. It would take at LEAST a HUNDRED items of whatever the condition tempering item is. Such as the bronze weapon kit, whetstone, ETC. That is EXTREMELY grindy and unfun for players especially when they want an upgrade. With this it should fix the problem and get everything back to working. With this it could also open the possibly for more advanced upgrading tools. 