### PR TITLE
Quick Megafortress bug fix, and rebalancing

### DIFF
--- a/maps/prefabs/64x64/syndicate_megafortress.dmm
+++ b/maps/prefabs/64x64/syndicate_megafortress.dmm
@@ -22,9 +22,9 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_security)
 "ap" = (
-/obj/structure/interactive/door/airlock/station/engineering/glass/supermatter,
 /obj/structure/interactive/wire/green,
 /obj/marker/cover_node/right,
+/obj/structure/interactive/door/airlock/station/engineering/glass,
 /turf/simulated/floor/tile/morphing/engineering,
 /area/mission/prefab/syndicate_megafortress/engineering)
 "aq" = (
@@ -59,9 +59,6 @@
 	dir = 8;
 	icon_state = "chair"
 	},
-/mob/living/advanced/npc/syndicate/shotgunnner{
-	dir = 8
-	},
 /obj/structure/interactive/lighting/fixture/tube/syndicate{
 	dir = 8;
 	icon_state = "preview"
@@ -81,17 +78,12 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_vault)
 "aS" = (
-/obj/decal/tile/cross/red{
-	dir = 4
-	},
-/obj/structure/interactive/bed,
-/obj/structure/interactive/misc/curtain_open,
-/mob/living/advanced/npc/syndicate{
-	icon_state = "directional";
-	dir = 4
+/obj/structure/interactive/lighting/fixture/floor/stronger,
+/mob/living/advanced/npc/syndicate/hardsuit{
+	dir = 8
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/barracks)
+/area/mission/prefab/syndicate_megafortress/external_hallways)
 "aV" = (
 /obj/marker/map_node,
 /obj/structure/interactive/wire/green,
@@ -135,11 +127,9 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_vault)
 "bt" = (
-/mob/living/advanced/npc/syndicate/hardsuit/advanced{
-	dir = 8
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/external_hallways)
+/obj/structure/interactive/vending/nanotrasen/janitor/guns,
+/turf/simulated/floor/tile/morphing/janitor,
+/area/mission/prefab/syndicate_megafortress/janitor_closet)
 "bx" = (
 /obj/decal/tile/cross/red{
 	dir = 4
@@ -230,6 +220,11 @@
 /obj/structure/table/rack/steel,
 /obj/item/experience_scroll/attribute/willpower,
 /obj/item/experience_scroll/attribute/willpower,
+/obj/item/tempering/quality/ranged/projectile,
+/obj/item/tempering/quality/ranged/projectile,
+/obj/item/tempering/quality/ranged/projectile,
+/obj/item/tempering/quality/ranged/projectile,
+/obj/item/tempering/quality/ranged/projectile,
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_vault2)
 "ck" = (
@@ -251,9 +246,6 @@
 /turf/simulated/floor/tile/morphing/engineering,
 /area/mission/prefab/syndicate_megafortress/engineering)
 "cq" = (
-/mob/living/advanced/npc/syndicate/shotgunnner{
-	dir = 8
-	},
 /obj/structure/interactive/atmospherics/scrubber,
 /turf/simulated/floor/tile/dark,
 /area/mission/prefab/syndicate_megafortress/janitor_closet)
@@ -438,8 +430,8 @@
 /turf/simulated/floor/tile/shuttle/dark/darker,
 /area/mission/prefab/syndicate_megafortress/syndi_office)
 "ek" = (
-/obj/structure/interactive/door/airlock/station/engineering/glass/supermatter,
 /obj/structure/interactive/wire/green,
+/obj/structure/interactive/door/airlock/station/engineering/glass,
 /turf/simulated/floor/tile/morphing/engineering,
 /area/mission/prefab/syndicate_megafortress/engineering)
 "en" = (
@@ -582,12 +574,6 @@
 /obj/structure/interactive/lighting/fixture/floor/stronger,
 /turf/simulated/floor/tile/dark/ish,
 /area/mission/prefab/syndicate_megafortress/cafeteria)
-"fG" = (
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 1
-	},
-/turf/simulated/wall/metal/syndicate/reinforced,
-/area/mission/prefab/syndicate_megafortress/external_hallways)
 "fH" = (
 /obj/structure/table/fancy,
 /obj/item/paper/book/cargo_catalog,
@@ -694,10 +680,6 @@
 /obj/marker/cover_node/right,
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/barracks)
-"gu" = (
-/mob/living/advanced/npc/syndicate/hardsuit,
-/turf/simulated/wall/metal/syndicate/reinforced,
-/area/mission/prefab/syndicate_megafortress/external_hallways)
 "gw" = (
 /mob/living/advanced/npc/syndicate/scientist{
 	dir = 1;
@@ -730,11 +712,11 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/level_1_hallways)
 "gG" = (
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 4
-	},
 /obj/marker/cover_node/right{
 	dir = 8
+	},
+/mob/living/advanced/npc/syndicate/hardsuit/advanced{
+	dir = 4
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_hq)
@@ -771,17 +753,10 @@
 /turf/simulated/floor/wood/rich,
 /area/mission/prefab/syndicate_megafortress/captains_quarters)
 "gZ" = (
-/obj/decal/tile/cross/red{
-	dir = 8
-	},
-/obj/structure/interactive/bed,
-/obj/structure/interactive/misc/curtain_open,
-/mob/living/advanced/npc/syndicate{
-	icon_state = "directional";
-	dir = 8
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/barracks)
+/obj/structure/interactive/atmospherics/vent,
+/mob/living/advanced/npc/syndicate/hardsuit/advanced,
+/turf/simulated/floor/tile,
+/area/mission/prefab/syndicate_megafortress/syndicate_medbay_fortress)
 "ha" = (
 /turf/simulated/wall/metal/syndicate,
 /area/mission/prefab/syndicate_megafortress/syndicate_vault2)
@@ -1140,10 +1115,6 @@
 	},
 /turf/simulated/floor/tile/morphing/medical,
 /area/mission/prefab/syndicate_megafortress/syndicate_medbay_fortress)
-"kF" = (
-/mob/living/advanced/npc/syndicate/scientist,
-/turf/simulated/floor/tile,
-/area/mission/prefab/syndicate_megafortress/syndicate_medbay_fortress)
 "kH" = (
 /obj/structure/interactive/barricade,
 /obj/structure/interactive/barricade{
@@ -1240,11 +1211,10 @@
 /turf/simulated/floor/tile/morphing/engineering,
 /area/mission/prefab/syndicate_megafortress/engineering)
 "lN" = (
-/mob/living/advanced/npc/syndicate/hardsuit/advanced{
-	dir = 1
-	},
+/obj/structure/interactive/lighting/fixture/floor/stronger,
+/mob/living/advanced/npc/syndicate/hardsuit,
 /turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/syndicate_vault)
+/area/mission/prefab/syndicate_megafortress/external_hallways)
 "lP" = (
 /obj/decal/tile/cross/red{
 	dir = 8
@@ -1258,7 +1228,7 @@
 /obj/structure/interactive/barricade{
 	dir = 8
 	},
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
+/mob/living/advanced/npc/syndicate/hardsuit/advanced{
 	dir = 1
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
@@ -1295,9 +1265,6 @@
 /area/mission/prefab/syndicate_megafortress/level_1_hallways)
 "lZ" = (
 /obj/marker/map_node,
-/mob/living/advanced/npc/syndicate/soldier{
-	dir = 8
-	},
 /turf/simulated/floor/tile/dark,
 /area/mission/prefab/syndicate_megafortress/lobby)
 "ma" = (
@@ -1412,13 +1379,6 @@
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/command_hallway)
-"mM" = (
-/obj/structure/interactive/wire/green,
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 4
-	},
-/turf/simulated/floor/tile/morphing/engineering,
-/area/mission/prefab/syndicate_megafortress/engineering)
 "mP" = (
 /obj/structure/interactive/bed,
 /obj/structure/carpet/red,
@@ -1699,7 +1659,6 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/external_hallways)
 "pl" = (
-/mob/living/advanced/npc/syndicate/soldier,
 /obj/marker/cover_node/right{
 	dir = 4
 	},
@@ -1782,12 +1741,6 @@
 /obj/marker/map_node,
 /turf/simulated/floor/tile/shuttle/dark/darker,
 /area/mission/prefab/syndicate_megafortress/syndi_office)
-"pZ" = (
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 4
-	},
-/turf/simulated/floor/tile/shuttle/dark/darker,
-/area/mission/prefab/syndicate_megafortress/syndicate_hq)
 "qa" = (
 /obj/structure/interactive/wire/green,
 /obj/marker/map_node,
@@ -1821,13 +1774,8 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/level_2_hallways)
 "qs" = (
-/obj/structure/scenery/fake_door/blast_door{
-	icon_state = "blast_closed";
-	dir = 4;
-	name = "High Secure Doors";
-	desc = "Are you sure releasing whatever is in here worth it?"
-	},
 /obj/structure/interactive/wire/green,
+/obj/structure/interactive/door/vault,
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_security_prison)
 "qt" = (
@@ -1870,13 +1818,6 @@
 /obj/structure/interactive/crate/trash,
 /turf/simulated/floor/tile/morphing/engineering,
 /area/mission/prefab/syndicate_megafortress/engineering)
-"qG" = (
-/mob/living/advanced/npc/syndicate/scientist{
-	dir = 8;
-	icon_state = "directional"
-	},
-/turf/simulated/floor/tile/morphing/medical,
-/area/mission/prefab/syndicate_megafortress/syndicate_medbay_fortress)
 "qH" = (
 /obj/marker/map_node,
 /turf/simulated/floor/tile/morphing/red/dark,
@@ -1892,25 +1833,10 @@
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_vault2)
-"qO" = (
-/obj/structure/interactive/wire/green,
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 8
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/sme_room)
 "qQ" = (
 /obj/marker/map_node,
 /turf/simulated/floor/tile/dark,
 /area/mission/prefab/syndicate_megafortress/external_hallways)
-"qS" = (
-/mob/living/advanced/npc/syndicate{
-	dir = 8;
-	icon_state = "directional"
-	},
-/obj/effect/cleanable/blood/splatter,
-/turf/simulated/floor/tile/coldroom,
-/area/mission/prefab/syndicate_megafortress/cafeteria)
 "qT" = (
 /obj/structure/table/reinforced/steel/dark,
 /obj/structure/interactive/misc/computer1{
@@ -2149,12 +2075,6 @@
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/level_1_hallways)
-"sY" = (
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 1
-	},
-/turf/simulated/floor/tile/shuttle/dark/darker,
-/area/mission/prefab/syndicate_megafortress/syndi_office)
 "tc" = (
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/external_hallways)
@@ -2162,9 +2082,6 @@
 /obj/structure/interactive/chair{
 	dir = 4;
 	icon_state = "chair"
-	},
-/mob/living/advanced/npc/syndicate/soldier{
-	dir = 4
 	},
 /obj/structure/interactive/lighting/fixture/tube/syndicate{
 	dir = 4;
@@ -2197,12 +2114,6 @@
 	},
 /mob/living/simple/turret/syndicate,
 /turf/simulated/floor/plating,
-/area/mission/prefab/syndicate_megafortress/external_hallways)
-"tF" = (
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 4
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/external_hallways)
 "tG" = (
 /obj/structure/interactive/wire/green,
@@ -2279,11 +2190,6 @@
 /obj/structure/interactive/power/apc,
 /turf/simulated/wall/metal/syndicate,
 /area/mission/prefab/syndicate_megafortress/janitor_closet)
-"uv" = (
-/obj/structure/interactive/lighting/fixture/tube/syndicate,
-/mob/living/advanced/npc/syndicate/hardsuit/advanced,
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/level_1_hallways)
 "uy" = (
 /obj/structure/interactive/door/airlock/syndicate,
 /obj/marker/cover_node/left{
@@ -2360,12 +2266,12 @@
 /turf/simulated/floor/tile/dark/er,
 /area/mission/prefab/syndicate_megafortress/syndicate_hq)
 "vr" = (
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 4
-	},
 /obj/marker/cover_node/left{
 	icon_state = "left";
 	dir = 8
+	},
+/mob/living/advanced/npc/syndicate/hardsuit/advanced{
+	dir = 4
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_hq)
@@ -2406,6 +2312,9 @@
 /area/mission/prefab/syndicate_megafortress/syndicate_vault)
 "vE" = (
 /obj/structure/interactive/atmospherics/vent,
+/mob/living/simple/silicon/syndieborg{
+	dir = 8
+	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/command_room)
 "vN" = (
@@ -2503,6 +2412,7 @@
 /mob/living/advanced/npc/syndicate/hardsuit/advanced{
 	dir = 4
 	},
+/obj/structure/interactive/wire/green,
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/command_room)
 "xe" = (
@@ -2514,8 +2424,9 @@
 	dir = 4;
 	icon_state = "chair"
 	},
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 1
+/mob/living/advanced/npc/syndicate/scientist{
+	dir = 1;
+	icon_state = "directional"
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/lobby)
@@ -2564,6 +2475,9 @@
 /obj/marker/cover_node/right{
 	dir = 8
 	},
+/mob/living/advanced/npc/syndicate/hardsuit/advanced{
+	dir = 4
+	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/level_2_hallways)
 "xA" = (
@@ -2602,27 +2516,13 @@
 /obj/structure/interactive/atmospherics/vent,
 /turf/simulated/floor/tile/dark,
 /area/mission/prefab/syndicate_megafortress/engineering)
-"xR" = (
-/obj/structure/interactive/chair{
-	dir = 8;
-	icon_state = "chair"
-	},
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 8
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/syndi_office)
 "xW" = (
 /obj/structure/interactive/lighting/fixture/tube/syndicate,
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/level_1_hallways)
 "xY" = (
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 1
-	},
-/obj/structure/interactive/wire/green,
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/syndi_office)
+/turf/simulated/wall/metal/syndicate/reinforced,
+/area/mission/prefab/syndicate_megafortress/engineering)
 "xZ" = (
 /obj/structure/interactive/door/airlock/syndicate,
 /obj/marker/cover_node/right{
@@ -2635,11 +2535,15 @@
 /turf/simulated/floor/tile/red,
 /area/mission/prefab/syndicate_megafortress/cafeteria)
 "yd" = (
-/mob/living/advanced/npc/syndicate/hardsuit{
+/obj/structure/interactive/chair{
+	dir = 4;
+	icon_state = "chair"
+	},
+/mob/living/advanced/npc/syndicate/soldier{
 	dir = 4
 	},
-/turf/simulated/wall/metal/syndicate/reinforced,
-/area/mission/prefab/syndicate_megafortress/external_hallways)
+/turf/simulated/floor/tile/morphing/red/dark,
+/area/mission/prefab/syndicate_megafortress/level_1_hallways)
 "yj" = (
 /obj/marker/cover_node/left{
 	icon_state = "left";
@@ -2647,12 +2551,6 @@
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/command_room)
-"yn" = (
-/mob/living/advanced/npc/syndicate/soldier{
-	dir = 8
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/level_1_hallways)
 "yo" = (
 /obj/marker/map_node/x2,
 /obj/structure/interactive/lighting/fixture/floor/stronger,
@@ -3079,12 +2977,6 @@
 "Cy" = (
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/command_room)
-"CB" = (
-/mob/living/advanced/npc/syndicate/hardsuit/advanced{
-	dir = 8
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/command_hallway)
 "CC" = (
 /obj/structure/interactive/atmospherics/vent,
 /turf/simulated/floor/tile/coldroom,
@@ -3129,7 +3021,7 @@
 /obj/structure/interactive/barricade{
 	dir = 4
 	},
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
+/mob/living/advanced/npc/syndicate/hardsuit/advanced{
 	dir = 1
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
@@ -3156,9 +3048,6 @@
 /area/mission/prefab/syndicate_megafortress/cafeteria)
 "Dr" = (
 /obj/marker/cover_node/left,
-/mob/living/advanced/npc/syndicate/hardsuit/advanced{
-	dir = 8
-	},
 /turf/simulated/floor/tile/shuttle/dark/darker,
 /area/mission/prefab/syndicate_megafortress/syndicate_security_prison)
 "Dt" = (
@@ -3204,9 +3093,8 @@
 /mob/living/advanced/npc/syndicate/hardsuit{
 	dir = 4
 	},
-/obj/structure/interactive/wire/green,
-/turf/simulated/floor/tile/morphing/engineering,
-/area/mission/prefab/syndicate_megafortress/engineering)
+/turf/simulated/floor/tile/morphing/red/dark,
+/area/mission/prefab/syndicate_megafortress/syndicate_vault)
 "Er" = (
 /obj/structure/interactive/barricade{
 	dir = 8
@@ -3276,6 +3164,7 @@
 "Fg" = (
 /obj/structure/table/fancy,
 /obj/item/cassette_player,
+/obj/item/container/simple/alcohol/beer,
 /turf/simulated/floor/wood/rich,
 /area/mission/prefab/syndicate_megafortress/captains_quarters)
 "Fh" = (
@@ -3315,9 +3204,6 @@
 /obj/structure/interactive/chair{
 	dir = 4;
 	icon_state = "chair"
-	},
-/mob/living/advanced/npc/syndicate/soldier{
-	dir = 4
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndi_office)
@@ -3405,10 +3291,10 @@
 	dir = 8;
 	icon_state = "chair"
 	},
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 1
-	},
 /obj/marker/map_node,
+/mob/living/advanced/npc/syndicate/hardsuit/advanced{
+	dir = 8
+	},
 /turf/simulated/floor/tile/shuttle/dark/darker,
 /area/mission/prefab/syndicate_megafortress/syndicate_security_prison)
 "Gt" = (
@@ -3533,7 +3419,7 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/command_hallway)
 "Hh" = (
-/obj/structure/interactive/door/airlock/station/engineering/glass/supermatter,
+/obj/structure/interactive/door/airlock/station/engineering/glass,
 /turf/simulated/floor/tile/morphing/engineering,
 /area/mission/prefab/syndicate_megafortress/engineering)
 "Hj" = (
@@ -3919,6 +3805,8 @@
 "KK" = (
 /obj/item/weapon/melee/holy_cog,
 /obj/structure/table/rack/steel,
+/obj/item/tempering/quality/melee,
+/obj/item/tempering/quality/melee,
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/syndicate_vault2)
 "KM" = (
@@ -4036,13 +3924,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mission/prefab/syndicate_megafortress/sme_room)
-"Mc" = (
-/mob/living/simple/turret/syndicate,
-/obj/structure/interactive/barricade{
-	dir = 2
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/syndicate_vault2)
 "Mh" = (
 /obj/structure/table/reinforced/steel/dark,
 /obj/structure/interactive/misc/computer2,
@@ -4064,12 +3945,15 @@
 /turf/simulated/floor/tile/shuttle/dark/darker,
 /area/mission/prefab/syndicate_megafortress/syndi_office)
 "Mw" = (
-/mob/living/simple/turret/syndicate,
-/obj/structure/interactive/barricade{
-	dir = 1
+/obj/decal/tile/cross/red{
+	dir = 8
 	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/syndicate_vault2)
+/mob/living/advanced/npc/syndicate{
+	icon_state = "directional";
+	dir = 8
+	},
+/turf/simulated/floor/tile/dark,
+/area/mission/prefab/syndicate_megafortress/barracks)
 "Mz" = (
 /obj/marker/map_node,
 /obj/structure/interactive/wire/green,
@@ -4363,9 +4247,6 @@
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/lobby)
 "Pp" = (
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 1
-	},
 /turf/simulated/floor/tile/shuttle/dark/darker,
 /area/mission/prefab/syndicate_megafortress/command_room)
 "Pq" = (
@@ -4513,12 +4394,6 @@
 	},
 /turf/simulated/floor/tile/dark,
 /area/mission/prefab/syndicate_megafortress/external_hallways)
-"QK" = (
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 8
-	},
-/turf/simulated/wall/metal/syndicate/reinforced,
-/area/mission/prefab/syndicate_megafortress/external_hallways)
 "QL" = (
 /obj/structure/interactive/chair{
 	dir = 8;
@@ -4545,6 +4420,9 @@
 /obj/marker/cover_node/left{
 	icon_state = "left";
 	dir = 8
+	},
+/mob/living/advanced/npc/syndicate/hardsuit/advanced{
+	dir = 4
 	},
 /turf/simulated/floor/tile/morphing/red/dark,
 /area/mission/prefab/syndicate_megafortress/level_2_hallways)
@@ -4782,6 +4660,7 @@
 /area/mission/prefab/syndicate_megafortress/captains_quarters)
 "Td" = (
 /obj/structure/table/fancy,
+/obj/item/container/simple/alcohol/beer,
 /turf/simulated/floor/wood/rich,
 /area/mission/prefab/syndicate_megafortress/captains_quarters)
 "Ti" = (
@@ -4914,13 +4793,6 @@
 /obj/structure/interactive/vending/syndicate/medicine,
 /turf/simulated/floor/tile/morphing/medical,
 /area/mission/prefab/syndicate_megafortress/syndicate_medbay_fortress)
-"UF" = (
-/obj/structure/interactive/wire/green,
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 4
-	},
-/turf/simulated/floor/tile/morphing/red/dark,
-/area/mission/prefab/syndicate_megafortress/syndicate_hq)
 "UG" = (
 /obj/structure/interactive/power/apc{
 	dir = 4
@@ -4984,12 +4856,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/mission/prefab/syndicate_megafortress/external_hallways)
-"Vh" = (
-/mob/living/advanced/npc/syndicate/hardsuit/advanced{
-	dir = 4
-	},
-/turf/simulated/floor/tile/shuttle/dark/darker,
-/area/mission/prefab/syndicate_megafortress/syndi_office)
 "Vm" = (
 /obj/structure/interactive/wire/green,
 /obj/marker/map_node,
@@ -5116,16 +4982,6 @@
 /obj/structure/interactive/crate/trash,
 /turf/simulated/floor/tile/shuttle/dark/darker,
 /area/mission/prefab/syndicate_megafortress/syndicate_hq)
-"WF" = (
-/mob/living/advanced/npc/syndicate/hardsuit{
-	dir = 4
-	},
-/obj/structure/interactive/lighting/fixture/tube/syndicate{
-	dir = 4;
-	icon_state = "preview"
-	},
-/turf/simulated/floor/tile/morphing/medical,
-/area/mission/prefab/syndicate_megafortress/syndicate_medbay_fortress)
 "WK" = (
 /obj/structure/table/fancy,
 /obj/item/paper/book/chemistry,
@@ -5165,10 +5021,6 @@
 	},
 /obj/structure/interactive/bed,
 /obj/structure/interactive/misc/curtain_open,
-/mob/living/advanced/npc/syndicate{
-	icon_state = "directional";
-	dir = 4
-	},
 /obj/structure/interactive/lighting/fixture/tube/syndicate{
 	dir = 4;
 	icon_state = "preview"
@@ -5444,10 +5296,9 @@
 /turf/simulated/floor/tile/morphing/medical,
 /area/mission/prefab/syndicate_megafortress/syndicate_medbay_fortress)
 "Zf" = (
-/obj/structure/interactive/chair/wood,
-/mob/living/advanced/npc/syndicate/hardsuit,
-/turf/simulated/floor/tile/dark/ish,
-/area/mission/prefab/syndicate_megafortress/cafeteria)
+/obj/structure/interactive/door/vault,
+/turf/simulated/floor/tile/morphing/red/dark,
+/area/mission/prefab/syndicate_megafortress/syndicate_security_prison)
 "Zi" = (
 /obj/marker/map_node,
 /obj/structure/interactive/wire/green,
@@ -5492,16 +5343,6 @@
 	},
 /turf/dmm_suite/no_wall,
 /area/dmm_suite/clear_area)
-"ZB" = (
-/obj/structure/interactive/misc/toilet{
-	dir = 4
-	},
-/obj/marker/map_node,
-/mob/living/advanced/npc/syndicate/hardsuit/elite{
-	dir = 4
-	},
-/turf/simulated/floor/tile,
-/area/mission/prefab/syndicate_megafortress/bathrooms)
 "ZD" = (
 /obj/structure/interactive/door/airlock/syndicate,
 /obj/structure/interactive/wire/green,
@@ -5660,7 +5501,7 @@ Rd
 eQ
 Jq
 Er
-QK
+eQ
 LP
 ln
 ln
@@ -5715,7 +5556,7 @@ JK
 ln
 ln
 Qn
-QK
+eQ
 Er
 Jq
 eQ
@@ -5789,7 +5630,7 @@ ln
 "}
 (4,1,1) = {"
 ln
-fG
+eQ
 iO
 yo
 kB
@@ -5802,15 +5643,15 @@ tc
 tc
 tc
 pj
-tF
+tc
 xe
 tc
 tc
-pj
+ia
 tc
 tc
 tc
-tF
+tc
 pj
 tc
 tc
@@ -5839,7 +5680,7 @@ tc
 tc
 tc
 pj
-tF
+tc
 tc
 tc
 nI
@@ -5850,7 +5691,7 @@ qQ
 Nk
 yo
 iN
-gu
+eQ
 ln
 "}
 (5,1,1) = {"
@@ -6064,7 +5905,7 @@ tj
 eO
 So
 Gw
-qS
+Hw
 Gw
 HR
 ih
@@ -6090,7 +5931,7 @@ uC
 Ma
 ct
 yJ
-qO
+Gv
 Gv
 Gv
 tG
@@ -6167,7 +6008,7 @@ zX
 pv
 pv
 wf
-xY
+jP
 aq
 yj
 ET
@@ -6649,7 +6490,7 @@ JK
 JK
 JK
 eQ
-wc
+tc
 Bu
 mX
 wb
@@ -6833,7 +6674,7 @@ mq
 BE
 UY
 nk
-Vh
+kK
 db
 pT
 pv
@@ -6869,7 +6710,7 @@ VX
 rf
 xr
 MH
-aS
+Kw
 bx
 WY
 bx
@@ -6952,14 +6793,14 @@ oB
 oB
 rf
 fN
-yA
+xr
 pv
 Ao
 Ko
 Ao
 TP
 Cj
-xR
+sg
 sg
 aL
 yH
@@ -6987,7 +6828,7 @@ EL
 pC
 EI
 mX
-Zf
+am
 vy
 YN
 kT
@@ -7018,7 +6859,7 @@ hF
 oB
 rf
 fN
-yn
+xr
 Vv
 Vv
 Vv
@@ -7122,7 +6963,7 @@ Ox
 Qp
 On
 Qp
-WF
+MT
 Ne
 ex
 eR
@@ -7146,7 +6987,7 @@ dT
 ZH
 BS
 eU
-ZB
+hF
 oB
 rf
 fN
@@ -7177,7 +7018,7 @@ JK
 JK
 JK
 eQ
-wc
+tc
 Bu
 ex
 IM
@@ -7226,7 +7067,7 @@ KR
 hl
 vs
 Mm
-sY
+kK
 pv
 nk
 dj
@@ -7243,7 +7084,7 @@ JK
 JK
 JK
 eQ
-pj
+lN
 Bu
 ex
 Qf
@@ -7253,7 +7094,7 @@ oq
 ck
 mz
 kk
-kz
+gZ
 wF
 Ox
 sO
@@ -7384,7 +7225,7 @@ na
 XG
 MY
 Ox
-qG
+Ox
 Ox
 Uz
 YM
@@ -7564,7 +7405,7 @@ dj
 aC
 pv
 Bu
-zz
+tc
 eQ
 JK
 JK
@@ -7612,7 +7453,7 @@ CE
 MH
 rf
 cm
-qW
+yd
 Vv
 Bh
 hl
@@ -7643,7 +7484,7 @@ tc
 Bu
 ex
 Vf
-kF
+wF
 BD
 wF
 BD
@@ -7671,7 +7512,7 @@ sA
 Le
 sA
 IE
-IE
+Mw
 IE
 IE
 CE
@@ -7682,7 +7523,7 @@ ch
 Vv
 hl
 pp
-qs
+Zf
 qs
 KR
 hl
@@ -7935,7 +7776,7 @@ FD
 wu
 CE
 gi
-gZ
+CE
 gi
 CE
 gi
@@ -8035,7 +7876,7 @@ JK
 JK
 JK
 eQ
-wc
+tc
 Bu
 oQ
 Td
@@ -8138,7 +7979,7 @@ Jn
 Jn
 YA
 yp
-uv
+xW
 HX
 xr
 xr
@@ -8270,7 +8111,7 @@ Jn
 Jn
 ok
 yp
-uv
+xW
 xr
 xr
 xr
@@ -8497,7 +8338,7 @@ JK
 JK
 JK
 eQ
-tc
+wc
 Bu
 oQ
 yq
@@ -8530,10 +8371,10 @@ TN
 lQ
 TN
 mI
-CB
+TN
 ZI
 Ng
-CB
+TN
 mI
 TN
 TN
@@ -8629,7 +8470,7 @@ JK
 JK
 JK
 eQ
-wc
+tc
 Bu
 oQ
 oQ
@@ -8708,7 +8549,7 @@ cH
 vN
 NV
 QE
-lN
+tY
 vN
 nN
 AX
@@ -8784,10 +8625,10 @@ Uq
 cj
 lT
 Uq
-Uq
-Py
-VW
-Uq
+FK
+FK
+cT
+FK
 Uq
 Ng
 rg
@@ -8795,8 +8636,8 @@ oN
 oN
 oV
 wZ
-UF
-jH
+rm
+wZ
 wZ
 oV
 oN
@@ -8860,10 +8701,10 @@ rg
 oG
 wI
 rA
-wZ
+jH
 VR
 uz
-wZ
+jH
 rA
 wI
 Ad
@@ -8896,7 +8737,7 @@ eQ
 pj
 Bu
 uT
-oe
+bt
 yv
 Km
 uT
@@ -8937,11 +8778,11 @@ rg
 iv
 Uh
 lt
-mM
+lt
 qy
 ZP
 aD
-En
+lt
 lt
 Ck
 iv
@@ -8982,10 +8823,10 @@ Uq
 FK
 Nx
 Uq
-Mc
+ZE
 ZE
 Xo
-Mw
+ZE
 Uq
 ii
 rg
@@ -9070,9 +8911,9 @@ iv
 Dj
 LS
 Xh
-iv
+xY
 Um
-iv
+xY
 Yx
 Ll
 Xt
@@ -9103,7 +8944,7 @@ rf
 cH
 CD
 NV
-tY
+En
 tY
 Zj
 Zj
@@ -9136,9 +8977,9 @@ iv
 lt
 GR
 qc
-iv
+xY
 Za
-iv
+xY
 qc
 Ll
 lt
@@ -9201,11 +9042,11 @@ rg
 iv
 lt
 Hx
-iv
-iv
+xY
+xY
 Um
-iv
-iv
+xY
+xY
 WW
 Ww
 iv
@@ -9254,24 +9095,24 @@ Uq
 ii
 rg
 iY
-pZ
+oN
 mU
 jH
 wZ
 wZ
 jH
 mU
-pZ
+oN
 iY
 rg
 kb
 lt
 mc
-iv
+xY
 In
 FY
 nM
-iv
+xY
 eg
 lt
 iv
@@ -9399,11 +9240,11 @@ rg
 iv
 Uh
 HM
-iv
+xY
 In
 Ll
 nM
-iv
+xY
 MR
 Yq
 iv
@@ -9412,7 +9253,7 @@ tc
 VN
 tc
 tc
-bt
+tc
 eQ
 ln
 ln
@@ -9465,11 +9306,11 @@ XX
 iv
 iv
 iv
-iv
-iv
-iv
-iv
-iv
+xY
+xY
+xY
+xY
+xY
 iv
 iv
 iv
@@ -9551,7 +9392,7 @@ ln
 "}
 (61,1,1) = {"
 ln
-fG
+eQ
 iO
 yo
 kB
@@ -9564,31 +9405,6 @@ tc
 tc
 tc
 pj
-Wf
-tc
-tc
-tc
-pj
-tc
-tc
-tc
-tc
-pj
-Wf
-tc
-tc
-tc
-pj
-tc
-tc
-tc
-Wf
-pj
-tc
-tc
-tc
-tc
-pj
 tc
 tc
 Wf
@@ -9600,7 +9416,32 @@ tc
 tc
 pj
 tc
+tc
+tc
+tc
+pj
+tc
 Wf
+tc
+tc
+pj
+tc
+tc
+tc
+tc
+pj
+tc
+tc
+tc
+tc
+pj
+tc
+tc
+tc
+tc
+aS
+tc
+tc
 tc
 tc
 pj
@@ -9612,7 +9453,7 @@ qQ
 Nk
 yo
 iN
-gu
+eQ
 ln
 "}
 (62,1,1) = {"
@@ -9686,7 +9527,7 @@ Rd
 eQ
 bA
 uo
-yd
+eQ
 Ib
 ln
 ln
@@ -9741,7 +9582,7 @@ JK
 ln
 ln
 ve
-yd
+eQ
 uo
 bA
 eQ


### PR DESCRIPTION
# What this PR does
Removed some syndicates that were placed directly in walls.
Removed a shitload of extra syndicates that bloated the difficulty for no real good reason.
Swapped some enemies around.
Replaced the blast doors with vault doors to the prisons.
And a bunch of other stuff to make it not aids to fight against. As well as fixing the map.

# Why it should be added to the game

These are quick rebalancing and fixes made now that the full map is ingame and that issues can be found easily.