### PR TITLE
Cleans up doctor's kit behavoir

### DIFF
--- a/code/_core/obj/item/doctor_bag.dm
+++ b/code/_core/obj/item/doctor_bag.dm
@@ -39,7 +39,7 @@
 
 	heal_all_limbs = !heal_all_limbs
 	if(heal_all_limbs)
-		activator.to_chat(span("notice","You decide to heal injuries of others more broadly, at the cost of healing power."))
+		activator.to_chat(span("notice","You decide to heal all limbs at once, at the cost of healing power."))
 	else
 		activator.to_chat(span("warning","You decide to focus on healing a singular limb."))
 
@@ -48,15 +48,13 @@
 /obj/item/doctor_bag/click_on_object(var/mob/activator,var/atom/object,location,control,params)
 
 	if(is_living(object) && is_living(activator))
-
-		var/mob/living/L = activator
-		var/mob/living/T = object
-
-		if(L == T)
+		var/mob/living/doctor_mob = activator
+		var/mob/living/treating_mob = object
+		if(doctor_mob == treating_mob)
 			activator.to_chat(span("warning","The surgical procedure is too complex to self-treat!"))
 			return TRUE
 
-		if(is_advanced(activator))
+		if(!heal_all_limbs && is_advanced(activator))
 			var/mob/living/advanced/A = activator
 			var/list/new_x_y = A.get_current_target_cords(params)
 			params[PARAM_ICON_X] = new_x_y[1]
@@ -66,10 +64,10 @@
 		if(can_be_treated(activator,object))
 			INTERACT_CHECK
 			INTERACT_CHECK_OBJECT
-			var/treatment_name = object.name
-			if(is_living(object.loc))
-				treatment_name = "[object.loc.name]'s [treatment_name]"
-			activator.visible_message(span("notice","\The [activator.name] begins treating \the [treatment_name]..."),span("notice","You begin treating \the [treatment_name]."))
+			activator.visible_message(
+				span("notice","[activator] begins treating [is_living(object.loc) ? "[object.loc]'s " : ""][object]..."),
+				span("notice","You begin treating [object].")
+			)
 			PROGRESS_BAR(activator,src,SECONDS_TO_DECISECONDS(3),src::treat(),activator,object) //Takes 3 seconds to get started.
 			PROGRESS_BAR_CONDITIONS(activator,src,src::can_be_treated(),activator,object)
 
@@ -84,7 +82,7 @@
 	INTERACT_CHECK_NO_DELAY(target)
 
 	if(!target.health)
-		activator.to_chat(span("warning","You can't treat \the [target.name]!"))
+		activator.to_chat(span("warning","You can't treat [target]!"))
 		return FALSE
 
 	var/mob/living/actual_target
@@ -94,41 +92,46 @@
 		actual_target = target.loc
 
 	if(!actual_target || !allow_helpful_action(activator.loyalty_tag,actual_target))
-		activator.to_chat(span("warning","You can't treat \the [target.name]!"))
+		activator.to_chat(span("warning","You can't treat [target]!"))
 		return FALSE
 
 	if(organic)
 		if(!target.health.organic)
-			activator.to_chat(span("warning","\The [src.name] can only treat organic limbs!"))
+			activator.to_chat(span("warning","[src] can only treat organic limbs!"))
 			return FALSE
 	else
 		if(target.health.organic)
-			activator.to_chat(span("warning","\The [src.name] can only treat non-organic limbs!"))
+			activator.to_chat(span("warning","[src] can only treat non-organic limbs!"))
 			return FALSE
 
 	if(target.health.damage[BRUTE] <= 0 && target.health.damage[BURN] <= 0)
 		if(is_organ(target))
 			var/obj/item/organ/O = target
 			if(O.bleeding <= 0)
-				activator.to_chat(span("notice","\The [O.name] doesn't need any more treatment!"))
+				activator.to_chat(span("notice","[O] doesn't need any more treatment!"))
 				return FALSE
 		else
-			activator.to_chat(span("notice","\The [target.name] doesn't need any more treatment!"))
+			activator.to_chat(span("notice","[target] doesn't need any more treatment!"))
 			return FALSE
 
 	return TRUE
 
 
 
-/obj/item/doctor_bag/proc/treat(var/mob/living/activator,var/atom/A)
+/**
+ * Arguments:
+ * * activator - Doctor doing the healing
+ * * healed_atom - Either the mob or an organ of a mob we are attempting to treat.
+ */
+/obj/item/doctor_bag/proc/treat(mob/living/activator, atom/healed_atom)
 
-	var/medicine_power = activator.get_skill_power(SKILL_MEDICINE,0,1,2) * (src.quality/100)
+	var/medicine_power = activator.get_skill_power(SKILL_MEDICINE,0,1,2) * (quality/100)
 
 	var/mob/living/target_as_living
-	if(is_organ(A) && is_living(A.loc))
-		target_as_living = A.loc
+	if(is_organ(healed_atom) && is_living(healed_atom.loc))
+		target_as_living = healed_atom.loc
 	else
-		target_as_living = A
+		target_as_living = healed_atom
 
 	if(target_as_living == activator) //Self-treatment penalty.
 		medicine_power *= 0.5
@@ -136,22 +139,22 @@
 	if(!target_as_living.horizontal) //Not horizontal penalty.
 		medicine_power *= 0.5
 
-	if(heal_all_limbs && is_living(A.loc)) // If we are on the second healing mode, heal more broadly at a severe penalty.
-		A = A.loc
+	if(heal_all_limbs && target_as_living) // If we are on the second healing mode, heal more broadly at a severe penalty.
+		healed_atom = target_as_living
 		medicine_power *= 0.25
 
 	medicine_power = max(medicine_power,0.1)
 
-	if(is_organ(A))
-		var/obj/item/organ/O = A
+	if(is_organ(healed_atom))
+		var/obj/item/organ/O = healed_atom
 		O.bleeding = max(0,O.bleeding - medicine_power) //Reduce bleeding.
 
-	var/brute_to_heal = (-heal_brute*medicine_power) + (-heal_brute_percent*A.health.damage[BRUTE]*medicine_power)
-	var/burn_to_heal = (-heal_burn*medicine_power) + (-heal_burn_percent*A.health.damage[BURN]*medicine_power)
+	var/brute_to_heal = (-heal_brute*medicine_power) + (-heal_brute_percent*healed_atom.health.damage[BRUTE]*medicine_power)
+	var/burn_to_heal = (-heal_burn*medicine_power) + (-heal_burn_percent*healed_atom.health.damage[BURN]*medicine_power)
 
 	var/total_healed = 0
 	if(brute_to_heal || burn_to_heal)
-		total_healed += A.health.adjust_loss_smart(brute = brute_to_heal, burn = burn_to_heal,robotic=!organic,organic=organic)
+		total_healed += healed_atom.health.adjust_loss_smart(brute = brute_to_heal, burn = burn_to_heal,robotic=!organic,organic=organic)
 
 	if(total_healed > 0 && is_player(activator) && !allow_hostile_action(activator.loyalty_tag,target_as_living))
 		var/mob/living/advanced/player/P = activator
@@ -165,23 +168,26 @@
 				var/currency_gain = min(target_as_player.insurance,CEILING(total_healed*income_multiplier,1))
 				if(currency_gain > 0)
 					target_as_player.insurance -= currency_gain
-					target_as_player.to_chat(span("notice","Your insurance was charged [currency_gain] credits for the treatment by [P.name]."))
+					target_as_player.to_chat(span("notice","Your insurance was charged [currency_gain] credits for the treatment by [P]."))
 				currency_gain += CEILING(total_healed*0.25*income_multiplier,1) //Bonus
 				var/currency_given = P.adjust_currency(currency_gain,silent=TRUE)
 				if(currency_given > 0)
-					P.to_chat(span("notice","You were paid [currency_given] credits for treating [target_as_player.name]."))
+					P.to_chat(span("notice","You were paid [currency_given] credits for treating [target_as_player]."))
 
 	if(reagents && !reagents.contains_lethal)
 		var/reagent_transfer = min(10,reagents.volume_current)
-		reagents.transfer_reagents_to(A.reagents,reagent_transfer, activator = activator)
+		reagents.transfer_reagents_to(healed_atom.reagents,reagent_transfer, activator = activator)
 
 	if(activator == target_as_living) //Self treatment.
-		activator.visible_message(span("notice","\The [activator.name] treats their [A.name]."),span("notice","You treat your [A.name]."))
+		activator.visible_message(span("notice","[activator] treats their [healed_atom]."),span("notice","You treat your [healed_atom]."))
+	else if(is_organ(healed_atom))
+		activator.visible_message(span("warning","[activator] treats [target_as_living]'s [healed_atom]."),span("notice","You treat [target_as_living]'s [healed_atom]."))
 	else
-		activator.visible_message(span("warning","\The [activator.name] treats \the [A.loc.name]'s [A.name]."),span("notice","You treat \the [A.loc.name]'s [A.name]."))
+		activator.visible_message(span("warning","[activator] treats [healed_atom]."),span("notice","You treat [healed_atom]."))
 
-	PROGRESS_BAR(activator,src,base_delay + max(0,added_delay*(1-medicine_power)),src::treat(),activator,A)
-	PROGRESS_BAR_CONDITIONS(activator,src,src::can_be_treated(),activator,A)
+
+	PROGRESS_BAR(activator,src,base_delay + max(0,added_delay*(1-medicine_power)),src::treat(),activator,healed_atom)
+	PROGRESS_BAR_CONDITIONS(activator,src,src::can_be_treated(),activator,healed_atom)
 
 	use_condition(1)
 


### PR DESCRIPTION
# What this PR does
Doctor's kits had some lingering bugs surrounding limb vs mob treatment which meant

1.  Alot of flavor text displayed weird, "Turf's mob" rather then what was intended "Mob's limb" it now displays the mob directly or mob's limb as intended.
2. Buncha uses of .name which arnet needed and can be handled by built in byond text macros.
3. The penalty for targeting all limbs was only applied to the first treat due to the way loc was used to find the treating mob.

New fixed tochats
<img width="411" height="143" alt="image" src="https://github.com/user-attachments/assets/56737009-3825-4348-add5-bb16d79473ac" />


# Why it should be added to the game
bugs bad.